### PR TITLE
Feature: Card sort form #1

### DIFF
--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -6,18 +6,19 @@ export default Ember.Component.extend({
     dragCard(obj, ops) {
       var cards = ops.target.cards;
       var buckets = ops.target.buckets;
+      var oldBucket;
 
       if (cards.contains(obj)) {
-          cards.removeObject(obj);
-      } else if (buckets.uncharacteristic.contains(obj)) {
-          buckets.uncharacteristic.removeObject(obj);
-      } else if (buckets.neutral.contains(obj)) {
-          buckets.neutral.removeObject(obj);
-      } else if (buckets.characteristic.contains(obj)){
-           buckets.characteristic.removeObject(obj);
+        oldBucket = cards;
+      } else {
+        for (var category in buckets) {
+          if (buckets[category].contains(obj)) {
+            oldBucket = buckets[category]
+          }
+        }
       }
 
-      this.sendAction('moveButton', obj, ops.target.bucket);
+      this.sendAction('moveCard', obj, oldBucket, ops.target.bucket);
     }
   }
 });

--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -3,10 +3,6 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   actions: {
-    moveButton(cards, bucket) {
-      var card = cards.shiftObject(); //always move top card from the stack
-      this.sendAction('moveButton', card, bucket);
-    },
     dragCard(obj, ops) {
       var cards = ops.target.cards;
       var buckets = ops.target.buckets;

--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -5,22 +5,22 @@ export default Ember.Component.extend({
   cards: null,
   buckets: null,
   actions: {
-    dragCard(obj, ops) {
+    dragCard(card, ops) {
       var cards = ops.target.cards;
       var buckets = ops.target.buckets;
       var oldBucket;
 
-      if (cards.contains(obj)) {
+      if (cards.contains(card)) {
         oldBucket = cards;
       } else {
         for (var category in buckets) {
-          if (buckets[category].contains(obj)) {
+          if (buckets[category].contains(card)) {
             oldBucket = buckets[category]
           }
         }
       }
 
-      this.sendAction('moveCard', obj, oldBucket, ops.target.bucket);
+      this.sendAction('moveCard', card, oldBucket, ops.target.bucket);
     }
   }
 });

--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -4,8 +4,24 @@ import Ember from 'ember';
 export default Ember.Component.extend({
   actions: {
     moveButton(cards, bucket) {
-      var card = cards.shiftObject();
+      var card = cards.shiftObject(); //always move top card from the stack
       this.sendAction('moveButton', card, bucket);
+    },
+    dragCard(obj, ops) {
+      var cards = ops.target.cards;
+      var buckets = ops.target.buckets;
+
+      if (cards.contains(obj)) {
+          cards.removeObject(obj);
+      } else if (buckets.uncharacteristic.contains(obj)) {
+          buckets.uncharacteristic.removeObject(obj);
+      } else if (buckets.neutral.contains(obj)) {
+          buckets.neutral.removeObject(obj);
+      } else if (buckets.characteristic.contains(obj)){
+           buckets.characteristic.removeObject(obj);
+      }
+
+      this.sendAction('moveButton', obj, ops.target.bucket);
     }
   }
 });

--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -2,6 +2,8 @@ import Ember from 'ember';
 
 
 export default Ember.Component.extend({
+  cards: null,
+  buckets: null,
   actions: {
     dragCard(obj, ops) {
       var cards = ops.target.cards;

--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+
+export default Ember.Component.extend({
+  actions: {
+    moveButton(cards, bucket) {
+      var card = cards.shiftObject();
+      this.sendAction('moveButton', card, bucket);
+    }
+  }
+});

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -18,7 +18,7 @@
 <div class="row">
     {{#each-in buckets as |bucket array|}}
       <div class="col-sm-4">
-          <h3 class="text-center">{{bucket}}</h3>
+          <h3 class="text-center">{{capitalize bucket}}</h3>
           {{#draggable-object-target bucket=bucket cards=cards buckets=buckets action="dragCard"}}
             <div class="well bucket">
               {{#each array as |card|}}

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -6,7 +6,7 @@
     "Continue."
 </p>
 <br>
-<div style="height: 75px; overflow: hidden; background-color:#f5f5f5; padding: 10px">
+<div class="well card-container">
     {{#each cards as |card|}}
       {{#draggable-object content=card}}
         <div class="handle item alert alert-info" data-id={{card.id}}>{{card.content}}</div>

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -1,5 +1,5 @@
-<p><b>Describe the situation.</b> Please indicate which items best described the situation you experienced
-    yesterday. There are XX items, which will appear one at a time. Begin by placing each item into one of
+<p><b>Describe the situation.</b> Please use these items to describe the situation you experienced
+    yesterday. There are 90 items, which will appear one at a time. Begin by placing each item into one of
     three boxes. Use the "Characteristic" box on the right for items that accurately describe the situation; use
     the "Uncharacteristic" box on the left for items that are undescriptive of the situation, and use the "Neutral"
     box for items that are irrelevant, unclear, or about which you are uncertain. When you are finished, press
@@ -13,10 +13,10 @@
       {{/draggable-object}}
     {{/each}}
 </div>
-<h5 style="text-align:center">{{cards.length}} items left</h5>
+<h4 style="text-align:center">{{cards.length}} items left</h4>
 <div class="row">
     <div class="col-sm-4">
-        <h2 class="text-center">Uncharacteristic</h2>
+        <h3 class="text-center">Uncharacteristic</h3>
         {{#draggable-object-target bucket="uncharacteristic" cards=cards buckets=buckets action="dragCard"}}
           <div class="well bucket">
             {{#each buckets.uncharacteristic as |card|}}
@@ -28,7 +28,7 @@
         {{/draggable-object-target}}
     </div>
     <div class="col-sm-4">
-        <h2 class="text-center">Neutral</h2>
+        <h3 class="text-center">Neutral</h3>
       {{#draggable-object-target bucket="neutral" cards=cards buckets=buckets action="dragCard"}}
           <div id="bucket2" class="well bucket">
               {{#each buckets.neutral as |card|}}
@@ -40,7 +40,7 @@
       {{/draggable-object-target}}
     </div>
     <div class="col-sm-4">
-        <h2 class="text-center">Characteristic</h2>
+        <h3 class="text-center">Characteristic</h3>
         {{#draggable-object-target bucket="characteristic" cards=cards buckets=buckets action="dragCard"}}
           <div id="bucket3" class="well bucket">
               {{#each buckets.characteristic as |card|}}

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -14,41 +14,20 @@
     {{/each}}
 </div>
 <h4 style="text-align:center">{{cards.length}} items left</h4>
+
 <div class="row">
-    <div class="col-sm-4">
-        <h3 class="text-center">Uncharacteristic</h3>
-        {{#draggable-object-target bucket="uncharacteristic" cards=cards buckets=buckets action="dragCard"}}
-          <div class="well bucket">
-            {{#each buckets.uncharacteristic as |card|}}
-              {{#draggable-object content=card}}
-                <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
-              {{/draggable-object}}
-            {{/each}}
-          </div>
-        {{/draggable-object-target}}
-    </div>
-    <div class="col-sm-4">
-        <h3 class="text-center">Neutral</h3>
-      {{#draggable-object-target bucket="neutral" cards=cards buckets=buckets action="dragCard"}}
-          <div id="bucket2" class="well bucket">
-              {{#each buckets.neutral as |card|}}
+    {{#each-in buckets as |bucket array|}}
+      <div class="col-sm-4">
+          <h3 class="text-center">{{bucket}}</h3>
+          {{#draggable-object-target bucket=bucket cards=cards buckets=buckets action="dragCard"}}
+            <div class="well bucket">
+              {{#each array as |card|}}
                 {{#draggable-object content=card}}
-                    <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+                  <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
                 {{/draggable-object}}
               {{/each}}
-          </div>
-      {{/draggable-object-target}}
-    </div>
-    <div class="col-sm-4">
-        <h3 class="text-center">Characteristic</h3>
-        {{#draggable-object-target bucket="characteristic" cards=cards buckets=buckets action="dragCard"}}
-          <div id="bucket3" class="well bucket">
-              {{#each buckets.characteristic as |card|}}
-                {{#draggable-object content=card}}
-                    <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
-                {{/draggable-object}}
-              {{/each}}
-          </div>
-        {{/draggable-object-target}}
-    </div>
+            </div>
+          {{/draggable-object-target}}
+      </div>
+    {{/each-in}}
 </div>

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -14,27 +14,6 @@
     {{/each}}
 </div>
 <h5 style="text-align:center">{{cards.length}} items left</h5>
-<div class="row" style="margin-top: 30px">
-    <div class="col-sm-4 text-center">
-        <button {{action "moveButton" cards "uncharacteristic"}}class="btn btn-lg btn-default" data-target="#bucket1">
-            <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
-            <div class="visible-xs">Move to Uncharacteristic</div>
-        </button>
-    </div>
-    <div class="col-sm-4 text-center">
-        <button {{action "moveButton" cards "neutral"}}class="btn btn-lg btn-default" data-target="#bucket2">
-            <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
-            <div class="visible-xs">Move to Neutral  </div>
-
-        </button>
-    </div>
-    <div class="col-sm-4 text-center">
-        <button {{action "moveButton" cards "characteristic"}}class="btn btn-lg btn-default" data-target="#bucket3">
-            <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
-            <div class="visible-xs">Move to Characteristic</div>
-        </button>
-    </div>
-</div>
 <div class="row">
     <div class="col-sm-4">
         <h2 class="text-center">Uncharacteristic</h2>

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -13,7 +13,7 @@
       {{/draggable-object}}
     {{/each}}
 </div>
-<h4 style="text-align:center">{{cards.length}} items left</h4>
+<h4 class="center">{{cards.length}} items left</h4>
 
 <div class="row">
     {{#each-in buckets as |bucket array|}}

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -1,0 +1,61 @@
+<p><b>Describe the situation.</b> Please indicate which items best described the situation you experienced
+    yesterday. There are XX items, which will appear one at a time. Begin by placing each item into one of
+    three boxes. Use the "Characteristic" box on the right for items that accurately describe the situation; use
+    the "Uncharacteristic" box on the left for items that are undescriptive of the situation, and use the "Neutral"
+    box for items that are irrelevant, unclear, or about which you are uncertain. When you are finished, press
+    "Continue."
+</p>
+<br>
+<div style="height: 75px; overflow: hidden; background-color:#f5f5f5; padding: 10px">
+    {{#each cards as |card|}}
+        <div class="handle item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+    {{/each}}
+</div>
+<h5 style="text-align:center">{{cards.length}} items left</h5>
+<div class="row" style="margin-top: 30px">
+    <div class="col-sm-4 text-center">
+        <button {{action "moveButton" cards "uncharacteristic"}}class="btn btn-lg btn-default" data-target="#bucket1">
+            <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
+            <div class="visible-xs">Move to Uncharacteristic</div>
+        </button>
+    </div>
+    <div class="col-sm-4 text-center">
+        <button {{action "moveButton" cards "neutral"}}class="btn btn-lg btn-default" data-target="#bucket2">
+            <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
+            <div class="visible-xs">Move to Neutral  </div>
+
+        </button>
+    </div>
+    <div class="col-sm-4 text-center">
+        <button {{action "moveButton" cards "characteristic"}}class="btn btn-lg btn-default" data-target="#bucket3">
+            <span class="glyphicon glyphicon-arrow-down" aria-hidden="true"></span>
+            <div class="visible-xs">Move to Characteristic</div>
+        </button>
+    </div>
+</div>
+<div class="row">
+    <div class="col-sm-4">
+        <h2 class="text-center">Uncharacteristic</h2>
+        <div class="well bucket">
+        {{#each buckets.uncharacteristic as |card|}}
+          <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+        {{/each}}
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <h2 class="text-center">Neutral</h2>
+        <div id="bucket2" class="well bucket">
+            {{#each buckets.neutral as |card|}}
+              <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+            {{/each}}
+        </div>
+    </div>
+    <div class="col-sm-4">
+        <h2 class="text-center">Characteristic</h2>
+        <div id="bucket3" class="well bucket">
+            {{#each buckets.characteristic as |card|}}
+              <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+            {{/each}}
+        </div>
+    </div>
+</div>

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -8,7 +8,9 @@
 <br>
 <div style="height: 75px; overflow: hidden; background-color:#f5f5f5; padding: 10px">
     {{#each cards as |card|}}
+      {{#draggable-object content=card}}
         <div class="handle item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+      {{/draggable-object}}
     {{/each}}
 </div>
 <h5 style="text-align:center">{{cards.length}} items left</h5>
@@ -36,26 +38,38 @@
 <div class="row">
     <div class="col-sm-4">
         <h2 class="text-center">Uncharacteristic</h2>
-        <div class="well bucket">
-        {{#each buckets.uncharacteristic as |card|}}
-          <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
-        {{/each}}
-        </div>
+        {{#draggable-object-target bucket="uncharacteristic" cards=cards buckets=buckets action="dragCard"}}
+          <div class="well bucket">
+            {{#each buckets.uncharacteristic as |card|}}
+              {{#draggable-object content=card}}
+                <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+              {{/draggable-object}}
+            {{/each}}
+          </div>
+        {{/draggable-object-target}}
     </div>
     <div class="col-sm-4">
         <h2 class="text-center">Neutral</h2>
-        <div id="bucket2" class="well bucket">
-            {{#each buckets.neutral as |card|}}
-              <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
-            {{/each}}
-        </div>
+      {{#draggable-object-target bucket="neutral" cards=cards buckets=buckets action="dragCard"}}
+          <div id="bucket2" class="well bucket">
+              {{#each buckets.neutral as |card|}}
+                {{#draggable-object content=card}}
+                    <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+                {{/draggable-object}}
+              {{/each}}
+          </div>
+      {{/draggable-object-target}}
     </div>
     <div class="col-sm-4">
         <h2 class="text-center">Characteristic</h2>
-        <div id="bucket3" class="well bucket">
-            {{#each buckets.characteristic as |card|}}
-              <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
-            {{/each}}
-        </div>
+        {{#draggable-object-target bucket="characteristic" cards=cards buckets=buckets action="dragCard"}}
+          <div id="bucket3" class="well bucket">
+              {{#each buckets.characteristic as |card|}}
+                {{#draggable-object content=card}}
+                    <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+                {{/draggable-object}}
+              {{/each}}
+          </div>
+        {{/draggable-object-target}}
     </div>
 </div>

--- a/app/helpers/capitalize.js
+++ b/app/helpers/capitalize.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export function capitalize([str,]/*, hash*/) {
+    return Ember.String.capitalize(str);
+}
+
+export default Ember.Helper.helper(capitalize);

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 
+
 var cards = [
  {id: 0, content: "Situation 0"},
  {id: 1, content: "Situation 1"},

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -40,10 +40,11 @@ export default Ember.Route.extend({
     controller.set('moveButton', card);
   },
   actions: {
-    moveButton(card, bucket) {
+    moveCard(card, oldBucket, target) {
       var data = this.modelFor(this.routeName);
       if (card !== null) {
-        data.buckets[bucket].unshiftObject(card);
+        oldBucket.removeObject(card);
+        data.buckets[target].unshiftObject(card);
       }
     }
   }

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -36,8 +36,6 @@ export default Ember.Route.extend({
   },
   setupController(controller, model) {
     this._super(controller, model);
-    let card = model.cards[0];
-    controller.set('moveButton', card);
   },
   actions: {
     moveCard(card, oldBucket, target) {

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -2,4 +2,34 @@ import Ember from 'ember';
 
 
 export default Ember.Route.extend({
+  model() {
+   return {
+     cards: [
+       {"id": 0, "content": "Situation 0"},
+       {"id": 1, "content": "Situation 1"},
+       {"id": 2, "content": "Situation 2"},
+       {"id": 3, "content": "Situation 3"},
+       {"id": 4, "content": "Situation 4"},
+       {"id": 5, "content": "Situation 5"}
+     ],
+     buckets: {
+       uncharacteristic: [],
+       neutral: [],
+       characteristic: []
+     }
+   }
+  },
+  setupController(controller, model) {
+    this._super(controller, model);
+    let card = model.cards[0];
+    controller.set('moveButton', card);
+  },
+  actions: {
+    moveButton(card, bucket) {
+      var data = this.modelFor(this.routeName);
+      if (card !== null) {
+        data.buckets[bucket].unshiftObject(card);
+      }
+    }
+  }
 });

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -34,16 +34,11 @@ export default Ember.Route.extend({
      }
    };
   },
-  setupController(controller, model) {
-    this._super(controller, model);
-  },
   actions: {
     moveCard(card, oldBucket, target) {
       var data = this.modelFor(this.routeName);
-      if (card !== null) {
-        oldBucket.removeObject(card);
-        data.buckets[target].unshiftObject(card);
-      }
+      oldBucket.removeObject(card);
+      data.buckets[target].unshiftObject(card);
     }
   }
 });

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -1,17 +1,31 @@
 import Ember from 'ember';
 
+var cards = [
+ {"id": 0, "content": "Situation 0"},
+ {"id": 1, "content": "Situation 1"},
+ {"id": 2, "content": "Situation 2"},
+ {"id": 3, "content": "Situation 3"},
+ {"id": 4, "content": "Situation 4"},
+ {"id": 5, "content": "Situation 5"}
+];
+
+// h/t: http://stackoverflow.com/a/6274398
+var shuffle = function(array) {
+  let n = array.length;
+  while (n > 0) {
+      let index = Math.floor(Math.random() * n);
+      n--;  //1
+      let temp = array[n];
+      array[n] = array[index];
+      array[index] = temp;
+  }
+  return array;
+};
 
 export default Ember.Route.extend({
   model() {
    return {
-     cards: [
-       {"id": 0, "content": "Situation 0"},
-       {"id": 1, "content": "Situation 1"},
-       {"id": 2, "content": "Situation 2"},
-       {"id": 3, "content": "Situation 3"},
-       {"id": 4, "content": "Situation 4"},
-       {"id": 5, "content": "Situation 5"}
-     ],
+     cards: shuffle(cards),
      buckets: {
        uncharacteristic: [],
        neutral: [],

--- a/app/routes/survey.js
+++ b/app/routes/survey.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 
 var cards = [
- {"id": 0, "content": "Situation 0"},
- {"id": 1, "content": "Situation 1"},
- {"id": 2, "content": "Situation 2"},
- {"id": 3, "content": "Situation 3"},
- {"id": 4, "content": "Situation 4"},
- {"id": 5, "content": "Situation 5"}
+ {id: 0, content: "Situation 0"},
+ {id: 1, content: "Situation 1"},
+ {id: 2, content: "Situation 2"},
+ {id: 3, content: "Situation 3"},
+ {id: 4, content: "Situation 4"},
+ {id: 5, content: "Situation 5"}
 ];
 
 // h/t: http://stackoverflow.com/a/6274398
@@ -31,7 +31,7 @@ export default Ember.Route.extend({
        neutral: [],
        characteristic: []
      }
-   }
+   };
   },
   setupController(controller, model) {
     this._super(controller, model);

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,11 +1,11 @@
 #header .navbar {
   background-color: #292929;
-  color: rgb(191, 191, 191);     
+  color: rgb(191, 191, 191);
 }
 #header .logo {
   max-height: 25px;
   position: relative;
-  top: 5px;  
+  top: 5px;
 }
 #header .text {
   font-size: 1.3em;
@@ -26,4 +26,9 @@
   position: absolute;
   bottom: 0px;
   width: 100%;
+}
+
+.bucket {
+    height: 300px;
+    overflow: auto;
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -32,3 +32,7 @@
     height: 300px;
     overflow: auto;
 }
+
+.item {
+    cursor: move;
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,3 +1,5 @@
+@import "components/card-sort";
+
 #header .navbar {
   background-color: #292929;
   color: rgb(191, 191, 191);
@@ -26,13 +28,4 @@
   position: absolute;
   bottom: 0px;
   width: 100%;
-}
-
-.bucket {
-    height: 300px;
-    overflow: auto;
-}
-
-.item {
-    cursor: move;
 }

--- a/app/styles/components/card-sort.scss
+++ b/app/styles/components/card-sort.scss
@@ -1,0 +1,14 @@
+.bucket {
+    height: 300px;
+    overflow: auto;
+}
+
+.item {
+    cursor: move;
+}
+
+.card-container {
+    height: 75px;
+    overflow: hidden;
+    padding: 10px;
+}

--- a/app/styles/components/card-sort.scss
+++ b/app/styles/components/card-sort.scss
@@ -12,3 +12,7 @@
     overflow: hidden;
     padding: 10px;
 }
+
+.center {
+  text-align:center;
+}

--- a/app/templates/survey.hbs
+++ b/app/templates/survey.hbs
@@ -1,2 +1,2 @@
 <h3>International Situations Project</h3>
-{{overview-info-form}}
+{{card-sort cards=model.cards buckets=model.buckets moveButton="moveButton"}}

--- a/app/templates/survey.hbs
+++ b/app/templates/survey.hbs
@@ -1,2 +1,2 @@
 <h3>International Situations Project</h3>
-{{card-sort cards=model.cards buckets=model.buckets moveButton="moveButton"}}
+{{card-sort cards=model.cards buckets=model.buckets moveCard="moveCard"}}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.4.2",
+    "ember-drag-drop": "^0.3.4",
     "ember-export-application-global": "^1.0.5",
     "ember-flag-icon-css": "git://github.com/samchrisinger/ember-flag-icon-css.git#639c32484d24e21668328f1cf382865af8290d74",
     "ember-getowner-polyfill": "1.0.1",

--- a/tests/integration/components/card-sort/component-test.js
+++ b/tests/integration/components/card-sort/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('card-sort', 'Integration | Component | card sort', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{card-sort}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#card-sort}}
+      template block text
+    {{/card-sort}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
## Ticket

https://openscience.atlassian.net/browse/EOSF-52
## Purpose

Add first card-sort form that allows users to drag and drop each card into one of three "buckets" 
## Changes

Added `card-sort` component and used the [ember-drag-drop](https://github.com/mharris717/ember-drag-drop) library to implement the sort/drag interface:  
![screen shot 2016-06-06 at 9 43 48 am](https://cloud.githubusercontent.com/assets/6414394/15824189/fb0e431a-2bcb-11e6-84ab-f3c3fc587fdf.png)
## Notes

This form should have the responses from the previous free response section at the top (will be added after the forms are stitched together)
