### PR TITLE
Feature: Card-sort updates

### DIFF
--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -7,6 +7,14 @@ export default Ember.Component.extend({
   buckets: null,
   buckets2: null,
   responses: null,
+  remaining: Ember.computed('buckets.uncharacteristic.[]', 'buckets.neutral.[]', 'buckets.characteristic.[]', function() {
+    var remaining = 0;
+    var buckets = this.buckets;
+    for (var category in buckets) {
+      remaining += buckets[category].length;
+    }
+    return remaining;
+  }),
   actions: {
     dragCard(card, ops) {
       var cards = ops.target.cards;

--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -7,13 +7,27 @@ export default Ember.Component.extend({
   buckets: null,
   buckets2: null,
   responses: null,
-  remaining: Ember.computed('buckets.uncharacteristic.[]', 'buckets.neutral.[]', 'buckets.characteristic.[]', function() {
-    var remaining = 0;
-    var buckets = this.buckets;
-    for (var category in buckets) {
-      remaining += buckets[category].length;
-    }
-    return remaining;
+  isValid: Ember.computed(
+    'buckets2.group1.extremely_uncharacteristic.cards.[]',
+    'buckets2.group1.quite_uncharacteristic.cards.[]',
+    'buckets2.group1.fairly_uncharacteristic.cards.[]',
+    'buckets2.group2.somewhat_uncharacteristic.cards.[]',
+    'buckets2.group2.relatively_neutral.cards.[]',
+    'buckets2.group2.somewhat_characteristic.cards.[]',
+    'buckets2.group3.fairly_characteristic.cards.[]',
+    'buckets2.group3.quite_characteristic.cards.[]',
+    'buckets2.group3.extremely_characteristic.cards.[]',
+    function() {
+      var buckets = this.buckets2;
+      for (var group in buckets) {
+        for (var category in buckets[group]) {
+          var bucket = buckets[group][category];
+            if (bucket.cards.length !== bucket.max) {
+              return false;
+            }
+          }
+      }
+      return true;
   }),
   actions: {
     dragCard(card, ops) {

--- a/app/components/card-sort/component.js
+++ b/app/components/card-sort/component.js
@@ -5,6 +5,7 @@ export default Ember.Component.extend({
   page: 'cardSort1',
   cards: null,
   buckets: null,
+  buckets2: null,
   responses: null,
   actions: {
     dragCard(card, ops) {

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -90,5 +90,5 @@
 {{#if (eq page 'cardSort1')}}
 <div class="btn btn-primary pull-right {{if (gt cards.length 0) 'disabled'}}" {{action "nextPage"}}>Continue</div>
 {{else if (eq page 'cardSort2')}}
-<div class="btn btn-primary pull-right {{if (gt remaining 0) 'disabled'}}" {{action "nextSection"}}>Continue</div>
+<div class="btn btn-primary pull-right {{if isValid 'enabled' 'disabled'}}" {{action "nextSection"}}>Continue</div>
 {{/if}}

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -88,7 +88,7 @@
 {{/if}}
 
 {{#if (eq page 'cardSort1')}}
-<div class="btn btn-primary pull-right" {{action "nextPage"}}>Continue</div>
+<div class="btn btn-primary pull-right {{if (gt cards.length 0) 'disabled'}}" {{action "nextPage"}}>Continue</div>
 {{else if (eq page 'cardSort2')}}
-<div class="btn btn-primary pull-right" {{action "nextSection"}}>Continue</div>
+<div class="btn btn-primary pull-right {{if (gt remaining 0) 'disabled'}}" {{action "nextSection"}}>Continue</div>
 {{/if}}

--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -64,7 +64,7 @@
       <div class="col-sm-4">
           <div class="row">
             {{#each-in categories as |category data|}}
-              <div class="col-sm-4">
+              <div id="smallBucket" class="col-sm-4">
               <h5 class="text-center">{{data.name}}</h5>
               <h5 class="text-center
                 {{if (gte data.cards.length data.max) (if (eq data.cards.length data.max) 'text-success' 'text-danger') ''}}">
@@ -74,7 +74,7 @@
                 <div class="well bucket">
                   {{#each data.cards as |card|}}
                     {{#draggable-object content=card}}
-                      <div class="item alert alert-info" data-id={{card.id}}>{{card.content}}</div>
+                      <div class="item alert alert-info small-card" style="font-size: 12px;" data-id={{card.id}}>{{card.content}}</div>
                     {{/draggable-object}}
                   {{/each}}
                 </div>

--- a/app/styles/components/card-sort.scss
+++ b/app/styles/components/card-sort.scss
@@ -16,3 +16,16 @@
 .center {
   text-align:center;
 }
+
+.small-card {
+  font-size: 10px;
+}
+
+#smallBucket .well {
+  padding:12px;
+}
+
+#smallBucket .alert {
+  padding: 10px;
+  margin-bottom: 12px;
+}


### PR DESCRIPTION
## Changes
- Only allow user to continue after first card-sort form once all cards have been sorted
- Only allow user to continue after second card-sort form when each bucket has the correct number of cards 
- Fix formatting for smaller cards (reduce padding & font-size)
- Add missing `bucket2`default attribute to card-sort component 
