### PR TITLE
Add link to survey from home page

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -7,26 +7,31 @@
 <div class="row">
   <div class="col-md-12">
     <h1> International Situations Project </h1>
-    
     <div class="well">
       <p>Enter your <strong>Study ID</strong> and <strong>Participant ID</strong> into the fields below. Please {{link-to 'contact us' 'contact'}} if you have any questions.</p>
       <div class="form">
         <div class="form-group">
           <label for="identifier">Study ID</label>
           <div class="form-input">
-	    {{input value=studyId}}
-	  </div>
+            {{input value=studyId}}
+          </div>
         </div>
-	<div class="form-group">
+	      <div class="form-group">
           <label for="participant">Participant ID</label>
           <div class="form-input">
-	    {{input value=pariticipantId}}
-	  </div>
+            {{input value=pariticipantId}}
+	        </div>
         </div>
-        <div class="form-group">	 
+        <div class="form-group">
           <button class="btn btn-primary" onclick={{action 'submit'}}>Continue >></button>
         </div>
       </div>
+    </div>
+    <div class="well">
+        <p>To test the survey, click below:</p>
+        <div class="form-group">
+          {{link-to 'Test >>' 'survey' class="btn btn-primary"}}
+        </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Purpose

Users have no way to access the survey unless they directly go to the `/survey` route.
## Changes

For testing purposes, add a button on the home page that takes users directly to the survey without having to login. Remove when login/consent flow works:  
![screen shot 2016-06-28 at 6 27 15 pm](https://cloud.githubusercontent.com/assets/6414394/16434498/485d9f64-3d5e-11e6-83ab-00f9bb0ff156.png)
