### PR TITLE
Make overview form field widths auto

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,3 +1,4 @@
+@import "components/overview-form";
 @import "components/card-sort";
 
 #header .navbar {

--- a/app/styles/components/overview-form.scss
+++ b/app/styles/components/overview-form.scss
@@ -1,0 +1,3 @@
+.form-control {
+  width:auto;
+}


### PR DESCRIPTION
In the first section of the survey, instead of the select and input fields taking up the full width of the page change width to auto so that it looks like this:  
![screen shot 2016-06-30 at 4 27 59 pm](https://cloud.githubusercontent.com/assets/6414394/16503184/e48cc32e-3edf-11e6-8d1c-b7466a601e21.png)
