### PR TITLE
Fix overview form formatting

### DIFF
--- a/app/components/overview-info-form/component.js
+++ b/app/components/overview-info-form/component.js
@@ -74,20 +74,24 @@ const formObject = {
         fields: {
             age: {
                 noneLabel: 'Please select',
-                validator: 'required-field'
+                validator: 'required-field',
+                fieldClass: 'overview-form-control'
             },
             gender: {
                 noneLabel: 'Please select',
                 "sort": function() {
                     return false;
                 },
-                validator: 'required-field'
+                validator: 'required-field',
+                fieldClass: 'overview-form-control'
             },
             ethnicity: {
-              validator: 'required-field'
+              validator: 'required-field',
+              fieldClass: 'overview-form-control'
             },
             firstLanguage: {
-              validator: 'required-field'
+              validator: 'required-field',
+              fieldClass: 'overview-form-control'
             },
             socioeconomicStatus: {
                 type: 'radio',
@@ -96,12 +100,14 @@ const formObject = {
                 validator: 'required-field'
             },
             birthLocation: {
-                validator: 'required-field'
+                validator: 'required-field',
+                fieldClass: 'overview-form-control'
             },
             residence: {
                 noneLabel: 'Please select',
                 optionLabels: ['Remote Rural', 'Rural', 'Suburban', 'Urban'],
-                validator: 'required-field'
+                validator: 'required-field',
+                fieldClass: 'overview-form-control'
             },
             isReligious: {
                 removeDefaultNone: true,
@@ -111,6 +117,9 @@ const formObject = {
                     return false;
                 },
                 validator: 'required-field'
+            },
+            religion: {
+              fieldClass: 'overview-form-control'
             },
             howReligious: {
                 type: 'radio',

--- a/app/styles/components/overview-form.scss
+++ b/app/styles/components/overview-form.scss
@@ -1,3 +1,9 @@
-.form-control {
-  width:auto;
+.overview-form-control {
+  select {
+    width:auto;
+  }
+
+  input {
+    width: auto;
+  }
 }


### PR DESCRIPTION
Instead of overriding the form-control class throughout the app, only override for select and input fields on the overview form.
