### PR TITLE
Feature: Replace alpaca forms [EOSF-92]

### DIFF
--- a/app/components/free-response-form/component.js
+++ b/app/components/free-response-form/component.js
@@ -10,7 +10,7 @@ var generateValidators = function(questions) {
       message: 'This field is required'
   });
   for (var question in questions) {
-      var isOptional = 'optional' in questions[question] && questions[question]['optional'];
+      var isOptional = questions[question].optional;
       if (!isOptional) {
         var key = 'questions.' + question + '.value';
         validators[key] = presence;

--- a/app/components/free-response-form/component.js
+++ b/app/components/free-response-form/component.js
@@ -1,75 +1,48 @@
 import Ember from 'ember';
 
-const formObject = Ember.Object.create({
-    schema: {
-        type: 'object',
-        properties: {
-            activity: {
-                type: 'string',
-                title: 'What were you doing yesterday at 10am/7pm?',
-                maxLength: 75
-            },
-            location: {
-                type: 'string',
-                title: 'Where were you?',
-                maxLength: 75
-            },
-            peoplePresent: {
-                type: 'string',
-                title: 'Who else was present? (If you were alone, please write "alone").',
-                maxLength: 75
-            }
-        }
-    },
-    options: {
-        form: {
-            buttons: {
-            submit: {
-                title: 'Continue',
-                styles: 'btn btn-primary'
-            }
-        }
-        },
-        fields: {
-            activity: {
-                type: 'textarea',
-                constrainMaxLength: true,
-                showMaxLengthIndicator: true,
-                validator: 'required-field'
-            },
-            location: {
-                type: 'textarea',
-                constrainMaxLength: true,
-                showMaxLengthIndicator: true,
-                validator: 'required-field'
-            },
-            peoplePresent: {
-                type: 'textarea',
-                constrainMaxLength: true,
-                showMaxLengthIndicator: true,
-                validator: 'required-field'
-            }
-        },
-        focus: false
+const MAX_LENGTH = 75;
+
+function getRemaining(value) {
+    var length = 0;
+    if (value !== null) {
+      length = value.length;
     }
-});
-
-const formActions = Ember.computed(function() {
-    var root = this;
-    return {
-        submit: function () {
-            this.refreshValidationState(true);
-            if (this.isValid()) {
-              var formData = this.getValue();
-              root.sendAction('update', formData, 'freeResponse');
-              root.sendAction('nextSection');
-            }
-        }
-    };
-});
-
+    return (MAX_LENGTH - length).toString();
+}
 
 export default Ember.Component.extend({
-  formSchema: formObject,
-  formActions: formActions
+  questions: {
+    q1: {
+      label: 'What were you doing yesterday at 10am/7pm?',
+      value: null
+    },
+    q2: {
+      label: 'Where were you?',
+      value: null
+    },
+    q3: {
+      label: 'Who else was present? (If you were alone, please write "alone").',
+      value: null
+    }
+  },
+  diff1: Ember.computed('questions.q1.value', function() {
+    return getRemaining(this.questions.q1.value);
+  }),
+  diff2: Ember.computed('questions.q2.value', function() {
+    return getRemaining(this.questions.q2.value);
+  }),
+  diff3: Ember.computed('questions.q3.value', function() {
+    return getRemaining(this.questions.q3.value);
+  }),
+  actions: {
+    nextSection() {
+      var formData = {};
+        var questions = this.get('questions');
+        for (var question in questions) {
+          formData[question] = questions[question]['value'];
+        }
+        this.sendAction('update', formData, 'freeResponse');
+        this.sendAction('nextSection');
+    }
+  }
 });

--- a/app/components/free-response-form/template.hbs
+++ b/app/components/free-response-form/template.hbs
@@ -9,5 +9,22 @@
     <li>Who else was present</li>
 </ol>
 <p>Please type your responses in the boxes below.</p>
-{{dynamic-form schema=formSchema formActions=formActions}}
-{{progress-bar pageNumber=2}}
+{{#bs-form}}
+    {{#bs-form-group}}
+      <label>{{questions.q1.label}}</label>
+      {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=questions.q1.value}}{{/textarea}}
+      <p class="text-muted">You have {{diff1}} characters remaining.</p>
+    {{/bs-form-group}}
+    {{#bs-form-group}}
+      <label>{{questions.q2.label}}</label>
+      {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=questions.q2.value}}{{/textarea}}
+      <p class="text-muted">You have {{diff2}} characters remaining.</p>
+    {{/bs-form-group}}
+    {{#bs-form-group}}
+      <label>{{questions.q3.label}}</label>
+      {{#textarea maxlength=75 rows="5" cols="40" class="form-control" value=questions.q3.value}}{{/textarea}}
+      <p class="text-muted">You have {{diff3}} characters remaining.</p>
+    {{/bs-form-group}}
+  <div class='btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled" "enabled"}}' {{action 'nextSection'}}>Continue</div>
+  {{progress-bar pageNumber=2}}
+{{/bs-form}}

--- a/app/components/overview-info-form/component.js
+++ b/app/components/overview-info-form/component.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import {validator, buildValidations} from 'ember-cp-validations';
 
 
 var range = function(start, stop) {
@@ -7,6 +8,22 @@ var range = function(start, stop) {
         options.push(i);
     }
     return options;
+};
+
+var generateValidators = function(questions) {
+  var validators = {};
+  var presence = validator('presence', {
+      presence:true,
+      message: 'This field is required'
+  });
+  for (var question in questions) {
+      var isOptional = 'optional' in questions[question] && questions[question]['optional'];
+      if (!isOptional) {
+        var key = 'questions.' + question + '.value';
+        validators[key] = presence;
+    }
+  }
+  return validators;
 };
 
 const questions = {
@@ -73,10 +90,13 @@ const questions = {
   }
 };
 
-export default Ember.Component.extend({
+const Validations = buildValidations(generateValidators(questions));
+
+export default Ember.Component.extend(Validations, {
   questions: questions,
   actions: {
     nextSection() {
+      if (this.get('validations.isValid')) {
         var formData = {};
         var questions = this.get('questions');
         for (var question in questions) {
@@ -85,5 +105,6 @@ export default Ember.Component.extend({
         this.sendAction('update', formData, 'overview');
         this.sendAction('nextSection');
       }
+    }
   }
 });

--- a/app/components/overview-info-form/component.js
+++ b/app/components/overview-info-form/component.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 
+
 var range = function(start, stop) {
     var options = [];
     for (var i=start; i <= stop; i++) {
@@ -8,146 +9,81 @@ var range = function(start, stop) {
     return options;
 };
 
-const formObject = {
-    schema: {
-        type: 'object',
-        properties: {
-            age: {
-                type: 'number',
-                title: 'Age',
-                enum: range(16, 100)
-            },
-            gender: {
-                type: 'string',
-                title: 'Gender',
-                enum: ['Male', 'Female', 'Other', 'I\'d rather not state']
-            },
-            ethnicity: {
-                type: 'string',
-                title: 'What is your ethnicity?'
-            },
-            firstLanguage: {
-                type: 'string',
-                title: 'What was your first language?'
-            },
-            socioeconomicStatus: {
-                type: 'number',
-                title: 'On a scale from 1 to 10 with 10 being people that are the most well off in society, and 1 ' +
-                         'being the people who are the least well off, where would you describe your family\'s position?',
-                enum: range(1, 10)
-            },
-            birthLocation: {
-                type: 'string',
-                title: 'Birth Country and City'
-            },
-            residence: {
-                type: 'string',
-                title: 'Hometown residence',
-                enum: ['remote rural', 'rural', 'suburban', 'urban']
-            },
-            isReligious: {
-                type: 'string',
-                title: 'Do you follow a religion?',
-                sort: false,
-                enum: ['yes', 'no']
-            },
-            religion: {
-                type: 'string',
-                title: 'If so, which one do you follow?'
-            },
-            howReligious: {
-                type: 'number',
-                title: 'On a scale from 1 to 10, how religious are you?',
-                enum: range(1, 10)
-            }
-        }
-    },
-    options: {
-        form: {
-            buttons: {
-                submit: {
-                    title: 'Continue',
-                    styles: 'btn btn-primary'
-                }
-            }
-        },
-        fields: {
-            age: {
-                noneLabel: 'Please select',
-                validator: 'required-field',
-                fieldClass: 'overview-form-control'
-            },
-            gender: {
-                noneLabel: 'Please select',
-                "sort": function() {
-                    return false;
-                },
-                validator: 'required-field',
-                fieldClass: 'overview-form-control'
-            },
-            ethnicity: {
-              validator: 'required-field',
-              fieldClass: 'overview-form-control'
-            },
-            firstLanguage: {
-              validator: 'required-field',
-              fieldClass: 'overview-form-control'
-            },
-            socioeconomicStatus: {
-                type: 'radio',
-                vertical: false,
-                removeDefaultNone: true,
-                validator: 'required-field'
-            },
-            birthLocation: {
-                validator: 'required-field',
-                fieldClass: 'overview-form-control'
-            },
-            residence: {
-                noneLabel: 'Please select',
-                optionLabels: ['Remote Rural', 'Rural', 'Suburban', 'Urban'],
-                validator: 'required-field',
-                fieldClass: 'overview-form-control'
-            },
-            isReligious: {
-                removeDefaultNone: true,
-                vertical: false,
-                optionLabels: ['Yes', 'No'],
-                "sort": function() {
-                    return false;
-                },
-                validator: 'required-field'
-            },
-            religion: {
-              fieldClass: 'overview-form-control'
-            },
-            howReligious: {
-                type: 'radio',
-                vertical: false,
-                removeDefaultNone: true,
-                validator: 'required-field'
-            }
-        },
-        focus: false
-    }
+const questions = {
+  q1: {
+    question: 'Age',
+    type: 'select',
+    scale: range(16, 100),
+    value: null
+  },
+  q2: {
+    question: 'Gender',
+    type: 'select',
+    scale: ['Male', 'Female', 'Other', 'I\'d rather not state'],
+    value: null
+  },
+  q3: {
+    question: 'What is your ethnicity?',
+    type: 'input',
+    value: null
+  },
+  q4: {
+    question: 'What was your first language?',
+    type: 'input',
+    value: null
+  },
+  q5: {
+    question: 'On a scale from 1 to 10 with 10 being people that are the most well off in society, and 1 ' +
+              'being the people who are the least well off, where would you describe your family\'s position?',
+    type: 'radio',
+    scale: range(1, 10),
+    labelTop: true,
+    value: null
+  },
+  q6: {
+    question: 'Birth Country and City',
+    type: 'input',
+    value: null
+  },
+  q7: {
+    question: 'Hometown residence',
+    type: 'select',
+    scale: ['remote rural', 'rural', 'suburban', 'urban'],
+    value: null
+  },
+  q8: {
+    question: 'Do you follow a religion?',
+    type: 'radio',
+    scale: ['Yes', 'No'],
+    labelTop: true,
+    value: null
+  },
+  q9: {
+    question: 'If so, which one do you follow?',
+    type: 'input',
+    optional: true,
+    value: null
+  },
+  q10: {
+    question: 'On a scale from 1 to 10, how religious are you?',
+    type: 'radio',
+    scale: range(1, 10),
+    labelTop: true,
+    value: null
+  }
 };
 
-const formActions = Ember.computed(function() {
-    var root = this;
-    return {
-        submit: function () {
-            this.refreshValidationState(true);
-            if (this.isValid()) {
-              var formData = this.getValue();
-              root.sendAction('update', formData, 'overview');
-              root.sendAction('nextSection');
-            }
-        }
-    };
-});
-
-
 export default Ember.Component.extend({
-  formSchema: formObject,
-  formActions: formActions
+  questions: questions,
+  actions: {
+    nextSection() {
+        var formData = {};
+        var questions = this.get('questions');
+        for (var question in questions) {
+          formData[question] = questions[question]['value'];
+        }
+        this.sendAction('update', formData, 'overview');
+        this.sendAction('nextSection');
+      }
+  }
 });

--- a/app/components/overview-info-form/template.hbs
+++ b/app/components/overview-info-form/template.hbs
@@ -4,5 +4,19 @@
     your attitudes and values. Based on these responses, when you have completed the study, you will receive
     individualized information about your personality that we hope you will find interesting.
 </p>
-{{dynamic-form schema=formSchema formActions=formActions}}
-{{progress-bar pageNumber=1}}
+{{#bs-form}}
+  {{#each-in questions as |question parts|}}
+    {{#bs-form-group}}
+      <label>{{parts.question}}</label>
+      {{#if (eq parts.type 'radio')}}
+        {{radio-group options=parts.scale labelTop=parts.labelTop value=parts.value}}
+      {{else if (eq parts.type 'select')}}
+        {{select-input options=parts.scale value=parts.value}}
+      {{else if (eq parts.type 'input')}}
+        {{#input class="form-control auto-width" value=parts.value}}{{/input}}
+      {{/if}}
+    {{/bs-form-group}}
+  {{/each-in}}
+  <div class='btn btn-primary pull-right {{if (v-get this 'isInvalid') "disabled" "enabled"}}' {{action 'nextSection'}}>Continue</div>
+  {{progress-bar pageNumber=1}}
+{{/bs-form}}

--- a/app/components/rating-form/component.js
+++ b/app/components/rating-form/component.js
@@ -27,7 +27,7 @@ var generateValidators = function(questions) {
   });
   for (var question in questions) {
     for (var item in questions[question]['items']) {
-      var isOptional = 'optional' in questions[question]['items'][item] && questions[question]['items'][item]['optional'];
+      var isOptional = questions[question]['items'][item].optional;
       if (!isOptional) {
         var key = 'questions.' + question + '.items.' + item + '.value';
         validators[key] = presence;

--- a/app/components/select-input/template.hbs
+++ b/app/components/select-input/template.hbs
@@ -1,4 +1,4 @@
-<select class="form-control select" onchange={{action (mut value) value="target.value"}}>
+<select class="form-control auto-width" onchange={{action (mut value) value="target.value"}}>
   <option value=null>Please select</option>
   {{#each options as |option|}}
     <option value={{option}} selected={{eq value option}}>{{option}}</option>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,7 +1,5 @@
-@import "components/overview-form";
 @import "components/card-sort";
 @import "components/radio-group";
-@import "components/select-input";
 @import "components/progress-bar";
 
 #header .navbar {
@@ -27,4 +25,8 @@
   position: relative;
   top: 50px;
   margin-bottom: 50px;
+}
+
+.auto-width {
+  width: auto;
 }

--- a/app/styles/components/overview-form.scss
+++ b/app/styles/components/overview-form.scss
@@ -1,9 +1,3 @@
-.overview-form-control {
-  select {
-    width:auto;
-  }
-
-  input {
-    width: auto;
-  }
+.auto-width {
+  width: auto;
 }

--- a/app/styles/components/overview-form.scss
+++ b/app/styles/components/overview-form.scss
@@ -1,3 +1,0 @@
-.auto-width {
-  width: auto;
-}

--- a/app/styles/components/select-input.scss
+++ b/app/styles/components/select-input.scss
@@ -1,3 +1,0 @@
-.select {
-  width: auto;
-}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.6",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-dynamic-forms": "0.1.1",
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",


### PR DESCRIPTION
Rewrite overview and free response forms to not use Alpaca.js, since that library has a separate way for handling internationalization (and there's an [issue](https://github.com/gitana/alpaca/issues/389) where one of it's default messages is not translate-able)

ticket: https://openscience.atlassian.net/browse/EOSF-92
