### PR TITLE
[Ready for Review] Experimenter Integration

### DIFF
--- a/app/authenticators/jam-jwt.js
+++ b/app/authenticators/jam-jwt.js
@@ -1,0 +1,46 @@
+import Ember from 'ember';
+import ENV from 'isp/config/environment';
+import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
+
+import { jwt_decode } from 'ember-cli-jwt-decode';
+
+import moment from 'moment';
+
+const {
+    $, RSVP
+} = Ember;
+
+export default BaseAuthenticator.extend({
+  url: `${ENV.JAMDB.url}/v1/auth`,
+  restore(data) {
+    let token = JSON.parse(atob(data.token.split('.')[1]));
+    if (token.exp > moment().unix()) {
+      return RSVP.resolve(data);
+    }
+    return RSVP.reject(data);
+  },
+  authenticate(attrs, token) {
+    if (token) {
+      var payload = jwt_decode(token);
+      var accountId = payload.sub.split('-').pop();
+      return new Ember.RSVP.Promise(resolve => {
+        resolve({
+          id: accountId,
+          token: token
+        });
+      });
+    }
+    return $.ajax({
+      method: 'POST',
+      url: this.url,
+      dataType: 'json',
+      contentType: 'application/json',
+      data: JSON.stringify({
+        data: {
+          type: 'users',
+          attributes: attrs
+        }
+      })
+    }).then(res => res.data.attributes);
+  }
+});

--- a/app/authorizers/jam-jwt.js
+++ b/app/authorizers/jam-jwt.js
@@ -1,0 +1,7 @@
+import Base from 'ember-simple-auth/authorizers/base';
+
+export default Base.extend({
+  authorize(sessionData, setHeader) {
+    setHeader('Authorization', sessionData.token);
+  }
+});

--- a/app/components/jam-auth/component.js
+++ b/app/components/jam-auth/component.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import ENV from 'isp/config/environment';
+
+export default Ember.Component.extend({
+  namespace: ENV.JAMDB.namespace,
+  collection: ENV.JAMDB.collection,
+
+  studyId: null,
+  participantId: null,
+
+  actions: {
+    authenticate() {
+      this.get('login')({
+        provider: 'self',
+        username: this.get('participantId'),
+        password: 'password',
+        studyId: this.get('studyId'),
+        namespace: this.get('namespace'),
+        collection: this.get('collection')
+      });
+    }
+  }
+});

--- a/app/components/jam-auth/component.js
+++ b/app/components/jam-auth/component.js
@@ -4,17 +4,13 @@ import ENV from 'isp/config/environment';
 export default Ember.Component.extend({
   namespace: ENV.JAMDB.namespace,
   collection: ENV.JAMDB.collection,
-
-  studyId: null,
   participantId: null,
-
   actions: {
     authenticate() {
       this.get('login')({
         provider: 'self',
         username: this.get('participantId'),
         password: 'password',
-        studyId: this.get('studyId'),
         namespace: this.get('namespace'),
         collection: this.get('collection')
       });

--- a/app/components/jam-auth/template.hbs
+++ b/app/components/jam-auth/template.hbs
@@ -1,12 +1,6 @@
 <div class="well">
-    <p>Enter your <strong>Study ID</strong> and <strong>Participant ID</strong> into the fields below. Please {{link-to 'contact us' 'contact'}} if you have any questions.</p>
+    <p>Enter your <strong>Participant ID</strong> into the fields below. Please {{link-to 'contact us' 'contact'}} if you have any questions.</p>
     <div class="form">
-      <div class="form-group">
-        <label for="identifier">Study ID</label>
-        <div class="form-input">
-          {{input value=studyId}}
-        </div>
-      </div>
       <div class="form-group">
         <label for="participant">Participant ID</label>
         <div class="form-input">

--- a/app/components/jam-auth/template.hbs
+++ b/app/components/jam-auth/template.hbs
@@ -1,0 +1,21 @@
+<div class="well">
+    <p>Enter your <strong>Study ID</strong> and <strong>Participant ID</strong> into the fields below. Please {{link-to 'contact us' 'contact'}} if you have any questions.</p>
+    <div class="form">
+      <div class="form-group">
+        <label for="identifier">Study ID</label>
+        <div class="form-input">
+          {{input value=studyId}}
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="participant">Participant ID</label>
+        <div class="form-input">
+          {{input value=participantId}}
+        </div>
+      </div>
+      <div class="form-group">
+        <button class="btn btn-primary" onclick={{action 'authenticate'}}>Continue >></button>
+      </div>
+    </div>
+</div>
+

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -14,7 +14,11 @@ export default Ember.Controller.extend({
     authenticate(attrs) {
       this.get('session')
         .authenticate('authenticator:jam-jwt', attrs)
-        .then(() => this.transitionToRoute('participate'));
+        .then(() => this.transitionToRoute('participate'))
+        .catch(() => this.send('toggleInvalidAuth'));
+    },
+    toggleInvalidAuth() {
+      this.toggleProperty('invalidAuth');
     },
     toggleLanguageSelector() {
       this.toggleProperty('showLanguageSelector');

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -1,22 +1,29 @@
 import Ember from 'ember';
+import ENV from 'isp/config/environment';
+
 
 export default Ember.Controller.extend({
-    studyId: null,
-    participantId: null,
-    showLanguageSelector: true,
-    selectedLanguage: null,
-    actions: {
-	submit ( ) {
-	    console.log(this.getProperties('studyId', 'participantId'));
-	},
-	toggleLanguageSelector() {
-	    this.toggleProperty('showLanguageSelector');
-	},
-	selectLanguage(language) {
-	    this.setProperties({
-		showLanguageSelector: false,
-		selectedLanguage: language
-	    });
-	}
+  session: Ember.inject.service('session'),
+  studyId: null,
+  participantId: null,
+  namespace: ENV.JAMDB.namespace,
+  collection: ENV.JAMDB.collection,
+  showLanguageSelector: true,
+  selectedLanguage: null,
+  actions: {
+    authenticate(attrs) {
+      this.get('session')
+        .authenticate('authenticator:jam-jwt', attrs)
+        .then(() => this.transitionToRoute('participate'));
+    },
+    toggleLanguageSelector() {
+      this.toggleProperty('showLanguageSelector');
+    },
+    selectLanguage(language) {
+      this.setProperties({
+        showLanguageSelector: false,
+        selectedLanguage: language
+      });
     }
+  }
 });

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,7 +4,6 @@ import ENV from 'isp/config/environment';
 
 export default Ember.Controller.extend({
   session: Ember.inject.service('session'),
-  studyId: null,
   participantId: null,
   namespace: ENV.JAMDB.namespace,
   collection: ENV.JAMDB.collection,

--- a/app/controllers/participate.js
+++ b/app/controllers/participate.js
@@ -5,7 +5,7 @@ const { service } = Ember.inject;
 export default Ember.Controller.extend({
     model: null,
     session: null,
-    //sessionAccount: service('session-account'),
+    sessionAccount: service('session-account'),
     store: Ember.inject.service(),
     isDirty: function() {
         // TODO: check the session model to see if it contains unsaved data

--- a/app/controllers/participate.js
+++ b/app/controllers/participate.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const { service } = Ember.inject;
+
+export default Ember.Controller.extend({
+    model: null,
+    session: null,
+    //sessionAccount: service('session-account'),
+    store: Ember.inject.service(),
+    isDirty: function() {
+        // TODO: check the session model to see if it contains unsaved data
+        var session = this.get('session');
+        return session.get('hasDirtyAttributes');
+    },
+    actions: {
+        saveSession(payload, callback) {
+            // Save a provided javascript object to a session object
+            var session = this.get('session');
+            session.setProperties(payload);
+            session.save().then(callback);
+            this.set('session', session);
+        }
+    }
+});

--- a/app/router.js
+++ b/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('faqs');
   this.route('contact');
   this.route('survey');
+  this.route('participate');
 });
 
 export default Router;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,4 +1,4 @@
 import Ember from 'ember';
+import UnauthenticatedRouteMixin from 'ember-simple-auth/mixins/unauthenticated-route-mixin';
 
-export default Ember.Route.extend({
-});
+export default Ember.Route.extend(UnauthenticatedRouteMixin);

--- a/app/routes/participate.js
+++ b/app/routes/participate.js
@@ -1,0 +1,29 @@
+import Ember from 'ember';
+//import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
+import ExpPlayerRouteMixin from 'exp-player/mixins/exp-player-route';
+import WarnOnExitRouteMixin from 'exp-player/mixins/warn-on-exit-route';
+
+
+export default Ember.Route.extend(ExpPlayerRouteMixin, WarnOnExitRouteMixin, {
+  store: Ember.inject.service(),
+
+  _getExperiment() {
+    return this.store.find('experiment', '578937f93de08a003bf381ad');
+  },
+  _getSession(params, experiment) { // jshint ignore: line
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      resolve(this.store.createRecord(experiment.get('sessionCollectionId'), {
+        experimentId: experiment.id,
+        profileId: 'TESTING',
+        completed: false,
+        feedback: '',
+        hasReadFeedback: '',
+        expData: {},
+        sequence: []
+      }));
+    });
+  },
+  model() {
+    return this._super();
+  }
+});

--- a/app/routes/participate.js
+++ b/app/routes/participate.js
@@ -1,5 +1,4 @@
 import Ember from 'ember';
-//import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-route-mixin';
 import ExpPlayerRouteMixin from 'exp-player/mixins/exp-player-route';
 import WarnOnExitRouteMixin from 'exp-player/mixins/warn-on-exit-route';
 
@@ -9,19 +8,6 @@ export default Ember.Route.extend(ExpPlayerRouteMixin, WarnOnExitRouteMixin, {
 
   _getExperiment() {
     return this.store.find('experiment', '578937f93de08a003bf381ad');
-  },
-  _getSession(params, experiment) { // jshint ignore: line
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      resolve(this.store.createRecord(experiment.get('sessionCollectionId'), {
-        experimentId: experiment.id,
-        profileId: 'TESTING',
-        completed: false,
-        feedback: '',
-        hasReadFeedback: '',
-        expData: {},
-        sequence: []
-      }));
-    });
   },
   model() {
     return this._super();

--- a/app/services/session-account.js
+++ b/app/services/session-account.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+
+const {
+    inject: {
+        service
+    },
+    RSVP
+} = Ember;
+
+
+export default Ember.Service.extend({
+    account: null,
+    profile: null,
+
+    session: service('session'),
+    store: service(),
+
+    _setAccount() {
+        const accountId = this.get('session.data.authenticated.id');
+        if (!Ember.isEmpty(accountId)) {
+            this.get('store').findRecord('account', accountId).then((account) => {
+                this.set('account', account);
+            });
+        }
+    },
+    init() {
+        var session = this.get('session');
+        session.on('invalidationSucceeded', () => {
+            this.setProperties({
+                account: null,
+                profile: null
+            });
+        });
+        session.addObserver('isAuthenticated', this, this._setAccount);
+        if (session.get('isAuthenticated')) {
+            this._setAccount();
+        }
+    },
+
+    loadCurrentUser() {
+        return new RSVP.Promise((resolve) => {
+            if (!this.get('session.isAuthenticated')) {
+                return resolve(null);
+            }
+            return resolve(this.get('account'));
+        });
+    },
+    setProfile: function(profile) {
+        this.set('profile', profile);
+    }
+});

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -7,32 +7,13 @@
 <div class="row">
   <div class="col-md-12">
     <h1> International Situations Project </h1>
-    <div class="well">
-      <p>Enter your <strong>Study ID</strong> and <strong>Participant ID</strong> into the fields below. Please {{link-to 'contact us' 'contact'}} if you have any questions.</p>
-      <div class="form">
-        <div class="form-group">
-          <label for="identifier">Study ID</label>
-          <div class="form-input">
-            {{input value=studyId}}
+      {{jam-auth login=(action 'authenticate')}}
+      <div class="well">
+          <p>To test the survey, click below:</p>
+          <div class="form-group">
+            {{link-to 'Test >>' 'survey' class="btn btn-primary"}}
           </div>
-        </div>
-	      <div class="form-group">
-          <label for="participant">Participant ID</label>
-          <div class="form-input">
-            {{input value=pariticipantId}}
-	        </div>
-        </div>
-        <div class="form-group">
-          <button class="btn btn-primary" onclick={{action 'submit'}}>Continue >></button>
-        </div>
       </div>
-    </div>
-    <div class="well">
-        <p>To test the survey, click below:</p>
-        <div class="form-group">
-          {{link-to 'Test >>' 'survey' class="btn btn-primary"}}
-        </div>
-    </div>
   </div>
 </div>
 {{#bs-modal body=false footer=false header=false open=showLanguageSelector}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -4,6 +4,12 @@
   </h3>
 {{/if}}
 
+{{#if invalidAuth}}
+    {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleInvalidAuth')}}
+        {{#bs-modal-body}}Invalid username or password.{{/bs-modal-body}}
+    {{/bs-modal}}
+{{/if}}
+
 <div class="row">
   <div class="col-md-12">
     <h1> International Situations Project </h1>

--- a/app/templates/participate.hbs
+++ b/app/templates/participate.hbs
@@ -1,13 +1,14 @@
 <div id="expContainer">
-{{
-  exp-player
-  experiment=experiment
-  session=session
-  pastSessions=pastSessions
+  <br>
+  {{
+    exp-player
+    experiment=experiment
+    session=session
+    pastSessions=pastSessions
 
-  saveHandler=(action 'saveSession')
-  frameIndex=0
+    saveHandler=(action 'saveSession')
+    frameIndex=0
 
-  fullScreenElementId='expContainer'
+    fullScreenElementId='expContainer'
   }}
 </div>

--- a/app/templates/participate.hbs
+++ b/app/templates/participate.hbs
@@ -1,0 +1,13 @@
+<div id="expContainer">
+{{
+  exp-player
+  experiment=experiment
+  session=session
+  pastSessions=pastSessions
+
+  saveHandler=(action 'saveSession')
+  frameIndex=0
+
+  fullScreenElementId='expContainer'
+  }}
+</div>

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,9 @@
     "handlebars": "3.0.3",
     "lodash": "~3.10.1",
     "jquery": "1.11.1",
-    "flag-icon-css": "^2.3.1"
+    "flag-icon-css": "^2.3.1",
+    "bcryptjs": "^2.3.0",
+    "swfobject": "*"
   },
   "devDependencies": {
     "font-awesome": "^4.6.1"

--- a/config/environment.js
+++ b/config/environment.js
@@ -30,6 +30,24 @@ module.exports = function(environment) {
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
 
+  if (environment === 'development') {
+        ENV.JAMDB = {
+            authorizer: 'jam-jwt',
+            collection:'accounts',
+            namespace: 'experimenter',
+            url: 'http://localhost:1212'
+        };
+    }
+
+    if (environment === 'staging' || environment === 'production') {
+      ENV.JAMDB = {
+          authorizer: 'jam-jwt',
+          collection:'accounts',
+          url: 'https://staging-metadata.osf.io',
+          namespace: 'isp'
+      };
+    }
+
   if (environment === 'test') {
     // Testem prefers this...
     ENV.baseURL = '/';

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-json-module": "0.0.2",
+    "ember-cli-moment-shim": "2.0.0",
     "ember-cli-qunit": "^1.4.0",
     "ember-cli-release": "0.2.8",
     "ember-cli-sass": "5.3.1",
@@ -37,15 +38,27 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-cp-validations": "2.9.2",
     "ember-data": "^2.4.2",
+    "ember-data-url-templates": "0.1.1",
     "ember-drag-drop": "^0.3.4",
     "ember-export-application-global": "^1.0.5",
     "ember-flag-icon-css": "git://github.com/samchrisinger/ember-flag-icon-css.git#144039ca0401e275c850c201d6ceb73ac5cb73bc",
+    "ember-get-config": "0.0.4",
     "ember-getowner-polyfill": "1.0.1",
     "ember-i18n": "4.2.2",
     "ember-load-initializers": "^0.5.1",
+    "ember-moment": "6.0.0",
     "ember-resolver": "^2.0.3",
+    "ember-simple-auth": "1.0.1",
     "ember-truth-helpers": "1.2.0",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "moment": "2.11.2",
+    "moment-timezone": "0.5.0"
+  },
+  "ember-addon": {
+    "paths": [
+      "lib/exp-models",
+      "lib/exp-player"
+    ]
   },
   "dependencies": {
     "ember-radio-buttons": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.4.0",
+    "ember-cli-jwt-decode": "0.0.2",
     "ember-cli-json-module": "0.0.2",
     "ember-cli-moment-shim": "2.0.0",
     "ember-cli-qunit": "^1.4.0",

--- a/tests/integration/components/jam-auth/component-test.js
+++ b/tests/integration/components/jam-auth/component-test.js
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('jam-auth', 'Integration | Component | jam auth', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{jam-auth}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#jam-auth}}
+      template block text
+    {{/jam-auth}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/unit/controllers/participate-test.js
+++ b/tests/unit/controllers/participate-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('controller:participate', 'Unit | Controller | participate', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+// Replace this with your real tests.
+test('it exists', function(assert) {
+  let controller = this.subject();
+  assert.ok(controller);
+});

--- a/tests/unit/routes/participate-test.js
+++ b/tests/unit/routes/participate-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:participate', 'Unit | Route | participate', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
## Purpose:

Integrate ISP with exp-addons, so that it is visible in experimenter.
## Changes:
- [x] Add route that embeds the exp-player (will replace the `survey` route)
- [x] Login/authenticate with jamdb (remove StudyID field)

Note:
The survey will only show the overview, free-response, and card-sort sections. The rating-form and "thank-you" page have not been merged: https://github.com/CenterForOpenScience/exp-addons/pull/99
