### PR TITLE
Fix validator keys

### DIFF
--- a/app/components/overview-info-form/component.js
+++ b/app/components/overview-info-form/component.js
@@ -18,13 +18,14 @@ var generateValidators = function(questions) {
     presence:true,
     message: 'This field is required'
   });
-  for (var question in questions) {
-    var isOptional = 'optional' in questions[question] && questions[question]['optional'];
+  for (var q=0; q < questions.length; q++) {
+    var isOptional = 'optional' in questions[q] && questions[q]['optional'];
     if (!isOptional) {
-      var key = 'questions.' + question + '.value';
+      var key = 'questions.' + q + '.value';
       validators[key] = presence;
     }
   }
+
   return validators;
 };
 


### PR DESCRIPTION
## Purpose

On the overview info form, even when a user fills out all of the fields the "Continue" button is disabled.
## Changes

Change the validator keys to reflect changes made to the structure of `questions` (now a list of dictionaries) so that the fields get validated properly.
