### PR TITLE
Fix card-sort template

### DIFF
--- a/app/components/card-sort/template.hbs
+++ b/app/components/card-sort/template.hbs
@@ -4,9 +4,9 @@
   <p>{{t 'qsort.sections.2.instructions'}}</p>
 {{/if}}
 <br>
-<h4 class="text-center"><b>{{responses.activity}}</b></h4>
-<h4 class="text-center"><b>{{responses.location}}</b></h4>
-<h4 class="text-center"><b>{{responses.peoplePresent}}</b></h4>
+<h4 class="text-center"><b>{{responses.q1}}</b></h4>
+<h4 class="text-center"><b>{{responses.q2}}</b></h4>
+<h4 class="text-center"><b>{{responses.q3}}</b></h4>
 <br>
 {{#if (eq page 'cardSort1')}}
   <div class="well card-container">


### PR DESCRIPTION
## Purpose

The card-sort template should display the responses from the previous form at the top of the page, but they are not there.
## Changes

Fix the variables for the responses in the card-sort template.
