### PR TITLE
Format rating labels onto two lines

### DIFF
--- a/app/components/radio-group/component.js
+++ b/app/components/radio-group/component.js
@@ -7,5 +7,6 @@ export default Ember.Component.extend({
   options: null,
   value: null,
   labelTop: null,
-  labels: null
+  labels: null,
+  formatLabel: false
 });

--- a/app/components/radio-group/template.hbs
+++ b/app/components/radio-group/template.hbs
@@ -1,21 +1,21 @@
 <div class="radio-group">
     {{#each options as |option index|}}
-      <label class="text-center label-text">
+      <label class="text-center label-text {{if formatLabel 'format-label'}}">
           {{#if labelTop}}
-            {{t option}}<br>
+            {{t option}}
             {{radio-button value=option checked=value}}
             {{#each-in labels as |ratings value|}}
               {{#if (eq value.rating index)}}
-                {{t value.label}}<br>
+                {{t value.label}}
               {{/if}}
             {{/each-in}}
           {{else}}
             {{#each-in labels as |ratings value|}}
               {{#if (eq value.rating index)}}
-                {{t value.label}}<br>
+                {{t value.label}}
               {{/if}}
             {{/each-in}}
-            {{radio-button value=option checked=value}}<br>
+            {{radio-button value=option checked=value}}
             {{t option}}
           {{/if}}
       </label>

--- a/app/components/rating-form/component.js
+++ b/app/components/rating-form/component.js
@@ -142,7 +142,10 @@ var questions = [
       translations.measures.questions['4'].options.quiteChar,
       translations.measures.questions['4'].options.extremelyChar
     ],
-    {labelTop: true}
+    {
+      labelTop: true,
+      formatLabel: true
+    }
   ),
   generateSchema(
     translations.measures.questions['5'].label,

--- a/app/components/rating-form/template.hbs
+++ b/app/components/rating-form/template.hbs
@@ -7,7 +7,7 @@
           {{#if item.description}}
             <p>{{t item.description}}</p>
           {{/if}}
-          {{radio-group options=question.scale labelTop=item.labelTop labels=item.labels value=item.value}}
+          {{radio-group options=question.scale labelTop=item.labelTop labels=item.labels formatLabel=item.formatLabel value=item.value}}
         {{/each}}
       {{else if (eq question.type 'select')}}
         {{select-input options=question.scale value=question.items.item1.value}}

--- a/app/styles/components/radio-group.scss
+++ b/app/styles/components/radio-group.scss
@@ -13,4 +13,11 @@
   font-weight:normal;
   text-align:center;
   display: inline-block;
+  white-space: pre-line;
+  overflow-wrap: break-word;
+  margin-right: 10px;
+}
+
+.format-label {
+  width: 9%;
 }


### PR DESCRIPTION
Make label width narrower and add `white-space: pre-line;` and `overflow-wrap: break-word;` so that the words wrap onto a second line. 

![screen shot 2016-08-02 at 10 29 24 am](https://cloud.githubusercontent.com/assets/6414394/17332265/20f6e35a-589c-11e6-8943-f7dd2cefdd71.png)
