### PR TITLE
Adjust rating label spacing

### DIFF
--- a/app/styles/components/radio-group.scss
+++ b/app/styles/components/radio-group.scss
@@ -20,4 +20,5 @@
 
 .format-label {
   width: 9%;
+  margin-top: -15px;
 }


### PR DESCRIPTION
Formatting the characteristic-scale rating labels onto two lines added extra space between the question and the labels. Adjust the margin of the labels to reduce the gap.
