### PR TITLE
Feature/update translations

### DIFF
--- a/app/locales/en-us/translations.js
+++ b/app/locales/en-us/translations.js
@@ -988,11 +988,11 @@ const translations = {
                 }
             },
             "2": {
-                "instructions": "Please describe what you were doing yesterday at [10 am/7 pm (This will be alternated among participants; odd numbered participants will describe 10 am; even numbered participants will be describe 7 pm)\n\nPlease be as specific as possible, and only write about ONE THING you were doing. For example, you can write \u201cI was shopping for groceries with my friend,\u201d but do NOT write \u201cI was shopping for groceries and then had dinner.\u201d If you were sleeping at that time, please say so. However, please also describe what you were doing right before you fell asleep, or right after you woke up.\n\nPlease describe:\n\n1. What you were doing\n2. Where you were\n3. Who else was present\n\nPlease type your responses in the boxes below.",
+                "instructions": "Please describe what you were doing yesterday at ##.\n\nPlease be as specific as possible, and only write about ONE THING you were doing. For example, you can write \u201cI was shopping for groceries with my friend,\u201d but do NOT write \u201cI was shopping for groceries and then had dinner.\u201d If you were sleeping at that time, please say so. However, please also describe what you were doing right before you fell asleep, or right after you woke up.\n\nPlease describe:\n\n1. What you were doing\n2. Where you were\n3. Who else was present\n\nPlease type your responses in the boxes below.",
                 "questions": {
                     "11": {
                         "characterCount": "0 out of 75 characters used",
-                        "label": "What were you doing yesterday at [10 am/7 pm]? (alternated as above)"
+                        "label": "What were you doing yesterday at ##?"
                     },
                     "12": {
                         "characterCount": "0 out of ## characters used ",

--- a/app/locales/en-us/translations.js
+++ b/app/locales/en-us/translations.js
@@ -991,7 +991,7 @@ const translations = {
                 "instructions": "Please describe what you were doing yesterday at ##.\n\nPlease be as specific as possible, and only write about ONE THING you were doing. For example, you can write \u201cI was shopping for groceries with my friend,\u201d but do NOT write \u201cI was shopping for groceries and then had dinner.\u201d If you were sleeping at that time, please say so. However, please also describe what you were doing right before you fell asleep, or right after you woke up.\n\nPlease describe:\n\n1. What you were doing\n2. Where you were\n3. Who else was present\n\nPlease type your responses in the boxes below.",
                 "questions": {
                     "11": {
-                        "characterCount": "0 out of 75 characters used",
+                        "characterCount": "0 out of ## characters used",
                         "label": "What were you doing yesterday at ##?"
                     },
                     "12": {

--- a/app/locales/en-us/translations.js
+++ b/app/locales/en-us/translations.js
@@ -1002,6 +1002,10 @@ const translations = {
                         "characterCount": "0 out of ## characters used",
                         "label": "Who else was present? (If you were alone, please write \u201calone\u201d)."
                     }
+                },
+                "times": {
+                  "10am": "10am",
+                  "7pm": "7pm"
                 }
             }
         }


### PR DESCRIPTION
## Purpose

Depending on the participantID, users are asked to describe a situation they experienced at 10am or 7pm. Because it's possible that the hard-coded numbers could get translated, separate them into their own variables and make the placeholder "##".
## Changes
- Add variables for "10am" and "7pm"
- Replace "[10am/7pm]" text with "##"
- Remove helper text that should not be shown to the user (e.g. "This will be alternated among participants...")
- Also replace hard-coded number "75" with "##" in character count 
