### PR TITLE
Add studyId to login page

### DIFF
--- a/app/components/isp-jam-auth/component.js
+++ b/app/components/isp-jam-auth/component.js
@@ -2,5 +2,4 @@ import Ember from 'ember';
 import ExpJamAuth from 'exp-player/components/jam-auth/component';
 
 export default ExpJamAuth.extend({
-  password: 'password'
 });

--- a/app/components/isp-jam-auth/template.hbs
+++ b/app/components/isp-jam-auth/template.hbs
@@ -1,6 +1,12 @@
 <div class="well">
-    <p>Enter your <strong>Participant ID</strong> into the fields below. Please {{link-to 'contact us' 'contact'}} if you have any questions.</p>
+    <p>Enter your <strong>Study ID</strong> and <strong>Participant ID</strong> into the fields below. Please {{link-to 'contact us' 'contact'}} if you have any questions.</p>
     <div class="form">
+      <div class="form-group">
+        <label for="participant">Study ID</label>
+        <div class="form-input">
+          {{input value=password}}
+        </div>
+      </div>
       <div class="form-group">
         <label for="participant">Participant ID</label>
         <div class="form-input">

--- a/app/routes/participate.js
+++ b/app/routes/participate.js
@@ -18,7 +18,7 @@ export default Ember.Route.extend(WarnOnExitRouteMixin, {
         if (pastSessions.length === 0) {
           return _this.store.createRecord(experiment.get('sessionCollectionId'), {
             experimentId: experiment.id,
-            profileId: account.get('username') + '.test',
+            profileId: account.get('username') + '.' + account.get('username'),
             completed: false,
             feedback: '',
             hasReadFeedback: '',


### PR DESCRIPTION
Purpose: 
- Add studyId to login page and map it to the account password field so that jamdb can authenticate that the participantID and studyID are correct
- Make profileID `account.get('username') + '.' + account.get('username')`

![screen shot 2016-08-25 at 11 40 20 am](https://cloud.githubusercontent.com/assets/6414394/17975709/bdcf8866-6ab8-11e6-9959-7b4c166b6d37.png)
