### PR TITLE
Update personality results page

### DIFF
--- a/app/components/results-page/component.js
+++ b/app/components/results-page/component.js
@@ -9,28 +9,28 @@ var VALUES = {
 };
 
 function averageScores(questions, reversed, items) {
-    var total = score(questions, items) + reverseScore(reversed, items);
-    return (total - 12)/48 * 100;
+  var total = score(questions, items) + reverseScore(reversed, items);
+  return (total - 12)/48 * 100;
 }
 
 function score(questions, items) {
-    var total = 0;
-    for (var i=0; i < questions.length; i++) {
-        var question = questions[i];
-        var value = items[question - 1];
-        total += VALUES[value];
-    }
-    return total;
+  var total = 0;
+  for (var i=0; i < questions.length; i++) {
+    var question = questions[i];
+    var value = items[question - 1];
+    total += VALUES[value];
+  }
+  return total;
 }
 
 function reverseScore(questions, items) {
-    var total = 0;
-    for (var i=0; i < questions.length; i++) {
-        var question = questions[i];
-        var value = items[question - 1];
-        total += (6 - VALUES[value]);
-    }
-    return total;
+  var total = 0;
+  for (var i=0; i < questions.length; i++) {
+    var question = questions[i];
+    var value = items[question - 1];
+    total += (6 - VALUES[value]);
+  }
+  return total;
 }
 
 export default Ember.Component.extend({
@@ -43,14 +43,15 @@ export default Ember.Component.extend({
     var conscientiousness = averageScores([13, 18, 33, 38, 43, 53], [3, 8, 23, 28, 48, 58], items);
     var neuroticism = averageScores([4, 9, 24, 29, 44, 49], [14, 19, 34, 39, 54, 59], items);
     var openness = averageScores([10, 15, 20, 35, 40, 60], [5, 25, 30, 45, 50, 55], items);
-    return [{
-      'name': 'feedback.extra',
-      'score': extraversion,
-      'description': {
-        'high': 'feedback.hiExtra',
-        'low': 'feedback.loExtra'
-      }
-    },
+    return [
+      {
+        'name': 'feedback.extra',
+        'score': extraversion,
+        'description': {
+          'high': 'feedback.hiExtra',
+          'low': 'feedback.loExtra'
+        }
+      },
       {
         'name': 'feedback.agree',
         'score': agreeableness,

--- a/app/components/results-page/component.js
+++ b/app/components/results-page/component.js
@@ -10,14 +10,14 @@ var VALUES = {
 
 function averageScores(questions, reversed, items) {
     var total = score(questions, items) + reverseScore(reversed, items);
-    return total / (questions.length + reversed.length);
+    return (total - 12)/48 * 100;
 }
 
 function score(questions, items) {
     var total = 0;
     for (var i=0; i < questions.length; i++) {
         var question = questions[i];
-        var value = items[question - 1].value;
+        var value = items[question - 1];
         total += VALUES[value];
     }
     return total;
@@ -27,8 +27,8 @@ function reverseScore(questions, items) {
     var total = 0;
     for (var i=0; i < questions.length; i++) {
         var question = questions[i];
-        var value = items[question - 1].value;
-        total += (5 - VALUES[value]);
+        var value = items[question - 1];
+        total += (6 - VALUES[value]);
     }
     return total;
 }
@@ -37,13 +37,14 @@ export default Ember.Component.extend({
   session: null,
   feedback: Ember.computed(function() {
     var session = this.get('session');
-    var items = session.get('expData')['0-0-rating-form']['responses']['4'].items;
-    var extraversion = averageScores([1, 11, 16, 26, 36], [6, 21, 31], items);
-    var agreeableness = averageScores([7, 17, 22, 32, 42], [2, 12, 27, 37], items);
-    var conscientiousness = averageScores([3, 13, 28, 33, 38], [8, 18, 23, 43], items);
-    var neuroticism = averageScores([4, 14, 19, 19, 39], [9, 24, 34], items);
-    var openness = averageScores([5, 10, 15, 20, 25, 30, 40, 44], [35, 41], items);
+    var items = session.get('expData')['4-4-rating-form']['responses']['4'];
+    var extraversion = averageScores([1, 6, 21, 41, 46, 56], [11, 16, 26, 31, 36, 51], items);
+    var agreeableness = averageScores([2, 7, 27, 32, 52, 57], [12, 17, 22, 37, 42, 47], items);
+    var conscientiousness = averageScores([13, 18, 33, 38, 43, 53], [3, 8, 23, 28, 48, 58], items);
+    var neuroticism = averageScores([4, 9, 24, 29, 44, 49], [14, 19, 34, 39, 54, 59], items);
+    var openness = averageScores([10, 15, 20, 35, 40, 60], [5, 25, 30, 45, 50, 55], items);
     return [{
+      'name': 'feedback.extra',
       'score': extraversion,
       'description': {
         'high': 'feedback.hiExtra',
@@ -51,6 +52,7 @@ export default Ember.Component.extend({
       }
     },
       {
+        'name': 'feedback.agree',
         'score': agreeableness,
         'description': {
           'high': 'feedback.hiAgree',
@@ -58,6 +60,7 @@ export default Ember.Component.extend({
         }
       },
       {
+        'name': 'feedback.consc',
         'score': conscientiousness,
         'description': {
           'high': 'feedback.hiConsc',
@@ -65,6 +68,7 @@ export default Ember.Component.extend({
         }
       },
       {
+        'name': 'feedback.neurot',
         'score': neuroticism,
         'description': {
           'high': 'feedback.hiNeurot',
@@ -72,6 +76,7 @@ export default Ember.Component.extend({
         }
       },
       {
+        'name': 'feedback.open',
         'score': openness,
         'description': {
           'high': 'feedback.hiOpen',

--- a/app/components/results-page/template.hbs
+++ b/app/components/results-page/template.hbs
@@ -4,11 +4,10 @@
   <br>
   {{#each feedback as |trait|}}
   <div class="row">
-    {{#if (gte trait.score 3.5)}}
+      <h5>{{t trait.name}}</h5>
+      <h5>{{t 'feedback.extraScore'}}{{trait.score}}</h5>
       <div class="col-md-12 alert alert-info">{{t trait.description.high}}</div>
-    {{else if (lt trait.score 3.5)}}
       <div class="col-md-12 alert alert-info">{{t trait.description.low}}</div>
-    {{/if}}
   </div>
   {{/each}}
   <p><b>{{t 'feedback.secondSection'}}</b></p>

--- a/app/components/results-page/template.hbs
+++ b/app/components/results-page/template.hbs
@@ -1,17 +1,19 @@
 <div class="row">
   <h3 class="text-center">{{t 'feedback.title'}}</h3>
   <p>{{t 'feedback.firstSection'}}</p>
+  <p>{{t 'feedback.secondSection'}}</p>
   <br>
   {{#each feedback as |trait|}}
   <div class="row">
       <h5>{{t trait.name}}</h5>
-      <h5>{{t 'feedback.extraScore'}}{{trait.score}}</h5>
+      <h5>{{t 'feedback.score'}}&nbsp;{{trait.score}}</h5>
       <div class="col-md-12 alert alert-info">{{t trait.description.high}}</div>
       <div class="col-md-12 alert alert-info">{{t trait.description.low}}</div>
   </div>
+  <br>
   {{/each}}
-  <p><b>{{t 'feedback.secondSection'}}</b></p>
   <p><b>{{t 'feedback.thirdSection'}}</b></p>
+  <p><b>{{t 'feedback.fourthSection'}}</b></p>
 </div>
 <div class="row exp-controls">
   <button class="btn btn-default pull-right">{{t 'thankyou.exitButton'}}</button>

--- a/app/components/results-page/template.hbs
+++ b/app/components/results-page/template.hbs
@@ -7,11 +7,12 @@
   <div class="row">
       <h5>{{t trait.name}}</h5>
       <h5>{{t 'feedback.score'}}&nbsp;{{trait.score}}</h5>
-      <div class="col-md-12 alert alert-info">{{t trait.description.high}}</div>
-      <div class="col-md-12 alert alert-info">{{t trait.description.low}}</div>
+      <div class="col-md-12 trait trait-border trait-border-bottom">{{t trait.description.high}}</div>
+      <div class="col-md-12 trait trait-border">{{t trait.description.low}}</div>
   </div>
   <br>
   {{/each}}
+  <br>
   <p><b>{{t 'feedback.thirdSection'}}</b></p>
   <p><b>{{t 'feedback.fourthSection'}}</b></p>
 </div>

--- a/app/locales/en-us/translations.js
+++ b/app/locales/en-us/translations.js
@@ -16,12 +16,10 @@ const translations = {
     },
     "feedback": {
         "agree": "Agreeableness",
-        "agreeScore": "Your score out of 100 possible: XX",
         "consc": "Conscientiousness",
-        "conscScore": "Your score out of 100 possible: XX",
         "extra": "Extraversion",
-        "extraScore": "Your score out of 100 possible: XX",
         "firstSection": "Based on decades of research, personality researchers agree that the most important individual differences in personality traits are described by five basic traits known as the \u201cBig Five\u201d: Extraversion, Agreeableness, Conscientiousness, Emotional Stability, and Openness to Experience.  The measures you just completed provide scores on each of these traits and your results are described below.",
+        "fourthSection": "Thank you for your participation!",
         "hiAgree": "High scorers tend to be considerate and polite in social interactions, and enjoy cooperating with others. They find it easy to trust people, and feel compassion for those in need. High scorers tend to be well liked by their peers, and they establish satisfying and stable close relationships. They are more likely to be religious, to serve in community leadership roles, and to do volunteer work. Older adults tend to score higher than younger adults.",
         "hiConsc": "High scorers tend to be organized and responsible. They work hard to achieve their goals, and complete tasks they have begun. High scorers tend to earn higher grades in school, and perform better in many occupations. They are more likely to be religious and hold conservative political attitudes. They tend to exercise more, have better physical health, and live longer. Older adults tend to score higher than younger adults.",
         "hiExtra": "High scorers tend to be talkative and energetic. They like being around people, and are comfortable asserting themselves in a group. High scorers tend to have more friends and dating partners, and are seen as more popular. They are more likely to serve in community leadership roles, and to do volunteer work. They tend to prefer energetic music, exercise more frequently, and are more likely to play a sport. They experience more frequent positive emotions, and react more strongly to positive events.",
@@ -33,11 +31,10 @@ const translations = {
         "loNeurot": "Low scorers tend to be emotionally sensitive, and have up-and-down mood swings. They experience more frequent negative emotions, and react more strongly to negative events. Younger adults tend to score lower than older adults.",
         "loOpen": "Low scorers tend to be traditional, practical, and like to stick with traditional ways of doing things. They prefer the familiar over the new, and the concrete over the abstract. Low scorers tend to prefer, and do better in, conventional and practical occupations such as crafts and trades.",
         "neurot": "Emotional Stability",
-        "neurotScore": "Your score out of 100 possible: XX",
         "open": "Openness to Experience",
-        "openScore": "Your score out of 100 possible: XX",
-        "secondSection": "We hope you enjoyed your participation in this study.",
-        "thirdSection": "Thank you for your participation!",
+        "score": "Your score out of 100 possible:",
+        "secondSection": "On each trait, scores above 60 can be considered high, and scores below 40 can be considered low. Descriptions of high and low scorers appear below. If your score is between 40 and 60, then your personality would probably be described as about average on the attributes listed.",
+        "thirdSection": "We hope you enjoyed your participation in this study.",
         "title": "Your Personality"
     },
     "global": {
@@ -1059,10 +1056,6 @@ const translations = {
                         "characterCount": "0 out of 75 characters used",
                         "label": "Who else was present? (If you were alone, please write \u201calone\u201d)."
                     }
-                },
-                "times": {
-                    "10am": "10am",
-                    "7pm": "7pm"
                 }
             }
         }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,5 +1,7 @@
 @import "components/radio-group";
 @import "components/progress-bar";
+@import "components/results-page";
+
 
 #header .navbar {
   background-color: #0c1462;

--- a/app/styles/components/results-page.scss
+++ b/app/styles/components/results-page.scss
@@ -1,0 +1,12 @@
+.trait {
+  background-color: #ecf7fd;
+  padding: 15px;
+}
+
+.trait-border {
+  border: 1px solid #31708f;
+}
+
+.trait-border-bottom {
+  border-bottom: none;
+}


### PR DESCRIPTION
# Changes
- Fix trait scoring
- Update template to display the trait score and both the high and low descriptions:  
  ![screen shot 2016-08-30 at 4 12 36 pm](https://cloud.githubusercontent.com/assets/6414394/18105223/9bc0d528-6ecc-11e6-8315-0fea50506fc6.png)
  ![screen shot 2016-08-30 at 4 13 03 pm](https://cloud.githubusercontent.com/assets/6414394/18105234/a8bfe35e-6ecc-11e6-9cc5-2b5e276ed2ec.png)
# Notes

The link to show the personality results page is added in https://github.com/CenterForOpenScience/exp-addons/pull/118
