### PR TITLE
Add script to generate consent form json [LEI-180]

### DIFF
--- a/scripts/consent_form_json.py
+++ b/scripts/consent_form_json.py
@@ -1,0 +1,36 @@
+import csv
+import json
+import collections
+import os.path
+
+# Content for each site's consent form
+files = os.listdir('/Users/Saman/Devel/isp/scripts/consent_forms/')
+
+
+def main():
+    data = dict()
+    for filename in files:
+        site_id = filename.split('.')[0]
+        data[site_id] = format_consent_form('consent_forms/' + filename)
+    f = open('consent.json', 'w')
+    f.write(json.dumps(data, indent=4, sort_keys=True))
+
+
+def format_consent_form(filename):
+    site_info = {
+      'paragraphs': {}
+    }
+    with open(filename, 'rb') as csvfile:
+        reader = csv.reader(csvfile)
+        for row in reader:
+            key = row[0]
+            value = row[1].strip(" ")
+            if 'paragraph' not in key:
+                site_info[key] = value
+            elif not value == "ADD OR REMOVE ROWS AS NEEDED":
+                site_info['paragraphs'][key] = row[1].strip(" ")
+    return site_info
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/consent_forms/test.csv
+++ b/scripts/consent_forms/test.csv
@@ -1,0 +1,7 @@
+title,Consent to Participate in Research
+consentLabel,I have read and understand the above statements and agree to participate.
+buttonLabel,Please accept terms to continue
+paragraph1,"Welcome to our study. Your participation will be in one session, which should take about one hour to complete. You will be instructed in the use of an on-line tool for recording information about a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes. At the end of the study, you will receive personalized information about your personality."
+paragraph2,"All of your responses will be kept confidential and identified only by a number (and not by your name). You are free to end your involvement in this research at any time without penalty of any sort. Further, you are free not to answer any questions in this study if you so choose."
+paragraph3,"If you have any questions about this study or your rights as a participant, you may contact the Project Coordinator, Erica Baranski, at erica.baranski.ucr.edu, or contact the Human Subjects Review Committee in the Research Office at the University of California, Riverside (1-951-827-5535). We sincerely appreciate your cooperation. Your cooperation makes this research possible."
+paragraph4,ADD OR REMOVE ROWS AS NEEDED


### PR DESCRIPTION
## Purpose

The text for each site's consent form will be in separate csv files.
## Changes
- Add a script that goes through each site's consent form csv file, formats it into json and writes it to a single json file.
- Add `scripts/consent_forms` folder which will hold all of the consent form csv files
