### PR TITLE
Get previous session if it exists

### DIFF
--- a/app/routes/participate/survey.js
+++ b/app/routes/participate/survey.js
@@ -22,20 +22,19 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
   },
   _getSession(params, experiment) { // jshint ignore: line
     return this.get('currentUser').getCurrentUser().then(([account, profile]) => {
-      return account.pastSessionsFor(experiment, profile).then((/* pastSessions */) => {
-        // TODO uncomment with https://github.com/CenterForOpenScience/isp/pull/51
-        // if (pastSessions.length === 0) {
-        return this.store.createRecord(experiment.get('sessionCollectionId'), {
-          experimentId: experiment.id,
-          profileId: account.get('username') + '.' + account.get('username'),
-          completed: false,
-          feedback: '',
-          hasReadFeedback: '',
-          expData: {},
-          sequence: []
-        });
-        //}
-        //return pastSessions[0];
+      return account.pastSessionsFor(experiment, profile).then((pastSessions) => {
+        if (pastSessions.content.length === 0) {
+          return this.store.createRecord(experiment.get('sessionCollectionId'), {
+            experimentId: experiment.id,
+            profileId: account.get('username') + '.' + account.get('username'),
+            completed: false,
+            feedback: '',
+            hasReadFeedback: '',
+            expData: {},
+            sequence: []
+          });
+        }
+        return pastSessions.content[0].record;
       });
     });
   },

--- a/app/routes/participate/survey.js
+++ b/app/routes/participate/survey.js
@@ -23,7 +23,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
   _getSession(params, experiment) { // jshint ignore: line
     return this.get('currentUser').getCurrentUser().then(([account, profile]) => {
       return account.pastSessionsFor(experiment, profile).then((pastSessions) => {
-        if (pastSessions.content.length === 0) {
+        if (pastSessions.get('length') === 0) {
           return this.store.createRecord(experiment.get('sessionCollectionId'), {
             experimentId: experiment.id,
             profileId: account.get('username') + '.' + account.get('username'),
@@ -34,7 +34,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
             sequence: []
           });
         }
-        return pastSessions.content[0].record;
+        return pastSessions.objectAt(0);
       });
     });
   },


### PR DESCRIPTION
Instead of creating a new session each time a user logs in, get their previous session if
they have one. That way, if a user does not complete the survey they can still login and complete their session.

Requires: https://github.com/CenterForOpenScience/exp-addons/pull/129/files to be merged
