### PR TITLE
Handle browser's back button [LEI-186]

### DIFF
--- a/app/controllers/participate/survey/index.js
+++ b/app/controllers/participate/survey/index.js
@@ -4,7 +4,7 @@ export default Ember.Controller.extend({
   model: null,
   session: null,
   frameIndex: 0,
-  framePage: 1,
+  framePage: 0,
   store: Ember.inject.service(),
   isDirty: function() {
     // TODO: check the session model to see if it contains unsaved data

--- a/app/controllers/participate/survey/index.js
+++ b/app/controllers/participate/survey/index.js
@@ -16,11 +16,6 @@ export default Ember.Controller.extend({
       this.set('session', session);
       this.get('session').save();
     },
-    updateFrameIndex(frameIndex) {
-      this.set('frameIndex', frameIndex + 1);
-      // reset framePage on frame change
-      this.set('framePage', 1);
-    },
     updateFramePage(framePage) {
       this.set('framePage', framePage);
     }

--- a/app/controllers/participate/survey/index.js
+++ b/app/controllers/participate/survey/index.js
@@ -15,9 +15,6 @@ export default Ember.Controller.extend({
     saveSession(session) {
       this.set('session', session);
       this.get('session').save();
-    },
-    updateFramePage(framePage) {
-      this.set('framePage', framePage);
     }
   }
 });

--- a/app/controllers/participate/survey/index.js
+++ b/app/controllers/participate/survey/index.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   model: null,
   session: null,
+  frameIndex: 0,
+  framePage: 1,
   store: Ember.inject.service(),
   isDirty: function() {
     // TODO: check the session model to see if it contains unsaved data
@@ -13,6 +15,14 @@ export default Ember.Controller.extend({
     saveSession(session) {
       this.set('session', session);
       this.get('session').save();
+    },
+    updateFrameIndex(frameIndex) {
+      this.set('frameIndex', frameIndex + 1);
+      // reset framePage on frame change
+      this.set('framePage', 1);
+    },
+    updateFramePage(framePage) {
+      this.set('framePage', framePage);
     }
   }
 });

--- a/app/routes/participate/survey/index.js
+++ b/app/routes/participate/survey/index.js
@@ -6,5 +6,23 @@ export default Ember.Route.extend({
     controller.set('experiment', this.controllerFor('participate.survey').get('experiment'));
     controller.set('session', session);
     controller.set('pastSessions', []);
+  },
+  actions: {
+    willTransition(transition) {
+      this._super(transition);
+      var frameIndex = this.controllerFor('participate.survey.index').get('frameIndex');
+      var framePage = this.controllerFor('participate.survey.index').get('framePage');
+      if (frameIndex !== 0) {
+        this.replaceWith('participate.survey.index');
+        // Disable back button in qsort page 2, and rating-form page 1
+        if (!(frameIndex === 2 && framePage === 2) && frameIndex !== 3) {
+          this.controllerFor('participate.survey.index').set('frameIndex', frameIndex - 1);
+        }
+        // Update pages within the rating-form
+        if (frameIndex === 3 && framePage !== 1) {
+          this.controllerFor('participate.survey.index').set('framePage', framePage - 1);
+        }
+      }
+    }
   }
 });

--- a/app/routes/participate/survey/index.js
+++ b/app/routes/participate/survey/index.js
@@ -15,11 +15,11 @@ export default Ember.Route.extend({
       if (frameIndex !== 0) {
         this.replaceWith('participate.survey.index');
         // Disable back button in qsort page 2, and rating-form page 1
-        if (!(frameIndex === 2 && framePage === 2) && frameIndex !== 3) {
+        if (!(frameIndex === 2 && framePage === 1) && frameIndex !== 3) {
           this.controllerFor('participate.survey.index').set('frameIndex', frameIndex - 1);
         }
         // Update pages within the rating-form
-        if (frameIndex === 3 && framePage !== 1) {
+        if (frameIndex === 3 && framePage !== 0) {
           this.controllerFor('participate.survey.index').set('framePage', framePage - 1);
         }
       }

--- a/app/templates/participate/survey/index.hbs
+++ b/app/templates/participate/survey/index.hbs
@@ -9,7 +9,6 @@
 
     frameIndex=frameIndex
     framePage=framePage
-    updateFrameIndex=(action 'updateFrameIndex')
     updateFramePage=(action 'updateFramePage')
 
     fullScreenElementId='expContainer'

--- a/app/templates/participate/survey/index.hbs
+++ b/app/templates/participate/survey/index.hbs
@@ -9,7 +9,6 @@
 
     frameIndex=frameIndex
     framePage=framePage
-    updateFramePage=(action 'updateFramePage')
 
     fullScreenElementId='expContainer'
   }}

--- a/app/templates/participate/survey/index.hbs
+++ b/app/templates/participate/survey/index.hbs
@@ -7,7 +7,10 @@
     pastSessions=pastSessions
     saveHandler=(action 'saveSession')
 
-    frameIndex=0
+    frameIndex=frameIndex
+    framePage=framePage
+    updateFrameIndex=(action 'updateFrameIndex')
+    updateFramePage=(action 'updateFramePage')
 
     fullScreenElementId='expContainer'
   }}


### PR DESCRIPTION
## Purpose

When a user clicks the back-button while on the survey, ensure that they go back to the previous survey page, not the consent form (the previous route).
## Changes

Override `willTransition` in the `participate.survey.index` route and go back to the previous frame/page.
## Testing Notes

Needs https://github.com/CenterForOpenScience/exp-addons/pull/133
