### PR TITLE
Fix transitioning to results page [LEI-209]

### DIFF
--- a/app/routes/participate/survey/index.js
+++ b/app/routes/participate/survey/index.js
@@ -10,6 +10,11 @@ export default Ember.Route.extend({
   actions: {
     willTransition(transition) {
       this._super(transition);
+
+      if (transition.targetName === 'participate.survey.results') {
+        return true;
+      }
+
       var frameIndex = this.controllerFor('participate.survey.index').get('frameIndex');
       var framePage = this.controllerFor('participate.survey.index').get('framePage');
       if (frameIndex !== 0) {


### PR DESCRIPTION
Fixes issue where users were redirected to the first page of the exp-rating-form instead of the personality results page. 
