### PR TITLE
Feature/flag picker ui fixes [LEI-211]

### DIFF
--- a/app/components/language-picker/countries.js
+++ b/app/components/language-picker/countries.js
@@ -30,6 +30,16 @@ export default [
         "name": "Belgium"
     },
     {
+        "code": "BG",
+        "languages": [
+            {
+                "code": "bg-BG",
+                "name": "Bulgarian"
+            }
+        ],
+        "name": "Bulgaria"
+    },
+    {
         "code": "BR",
         "languages": [
             {

--- a/app/components/language-picker/countries.js
+++ b/app/components/language-picker/countries.js
@@ -14,7 +14,7 @@ export default [
         "languages": [
             {
                 "code": "de-AT",
-                "name": "Deutsch (AT)"
+                "name": "German (AT)"
             }
         ],
         "name": "Austria"
@@ -504,7 +504,7 @@ export default [
             },
             {
                 "code": "de-CH",
-                "name": "Deutsch (CH)"
+                "name": "German (CH)"
             }
         ],
         "name": "Switzerland"


### PR DESCRIPTION
- Add Bulgarian to flag picker
- Use "German" instead of "Deutsch" as the language label
