### PR TITLE
Sort languages by country name

### DIFF
--- a/app/components/language-picker/component.js
+++ b/app/components/language-picker/component.js
@@ -12,16 +12,17 @@ export default Ember.Component.extend({
         country.languages.forEach((lang) => {
           langs.push({
             countryCode: country.code,
+            countryName: country.name,
             name: lang.name,
             code: lang.code
           });
         });
       });
       langs.sort(function(a, b) {
-        if (a.countryCode > b.countryCode) {
+        if (a.countryName > b.countryName) {
           return 1;
         }
-        if (a.countryCode < b.countryCode) {
+        if (a.countryName < b.countryName) {
           return -1;
         }
         return 0;


### PR DESCRIPTION
Instead of sorting languages by country code, sort by country name.
