### PR TITLE
Feature: Re-enable login button if user enters wrong username and/or password [LEI-238]

### DIFF
--- a/app/components/isp-jam-auth/template.hbs
+++ b/app/components/isp-jam-auth/template.hbs
@@ -13,7 +13,7 @@
         </div>
       </div>
       <div class="form-group">
-        <button disabled={{disabled}} class="btn btn-primary" onclick={{action 'authenticate'}}>{{t 'global.continueLabel'}}</button>
+        <button disabled={{disableLogin}} class="btn btn-primary" onclick={{action 'authenticate'}}>{{t 'global.continueLabel'}}</button>
       </div>
     </div>
 </div>

--- a/app/components/isp-jam-auth/template.hbs
+++ b/app/components/isp-jam-auth/template.hbs
@@ -13,7 +13,7 @@
         </div>
       </div>
       <div class="form-group">
-        <button disabled={{if (or authenticating (not (and password username))) true false}} class="btn btn-primary" onclick={{action 'authenticate'}}>{{t 'global.continueLabel'}}</button>
+        <button disabled={{disabled}} class="btn btn-primary" onclick={{action 'authenticate'}}>{{t 'global.continueLabel'}}</button>
       </div>
     </div>
 </div>

--- a/app/controllers/participate/login.js
+++ b/app/controllers/participate/login.js
@@ -11,6 +11,7 @@ export default Ember.Controller.extend({
   showLanguageSelector: true,
   selectedLanguage: null,
   locale: null,
+  authenticating: false,
   actions: {
     authenticate(attrs) {
       return this.get('session')
@@ -25,6 +26,7 @@ export default Ember.Controller.extend({
         .catch((e) => {
           if (e.status === 404) {
             this.send('toggleInvalidAuth');
+            this.set('authenticating', false);
           } else if (e.name === 'TransitionAborted') {
             this.send('toggleInvalidLocale');
           }

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -24,7 +24,7 @@
     <div class="row">
       <div class="col-md-12">
         <h1>International Situations Project</h1>
-        {{isp-jam-auth authenticating=authenticating login=(action 'authenticate')}}
+        {{isp-jam-auth invalidAuth=invalidAuth authenticating=authenticating login=(action 'authenticate')}}
       </div>
     </div>
   </div>

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -24,7 +24,7 @@
     <div class="row">
       <div class="col-md-12">
         <h1>International Situations Project</h1>
-        {{isp-jam-auth login=(action 'authenticate')}}
+        {{isp-jam-auth authenticating=authenticating login=(action 'authenticate')}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-238
Companion to: https://github.com/CenterForOpenScience/exp-addons/pull/159
## Purpose

When a user enters a username and password and clicks the "Continue" button to login, the button is disabled during authentication. However, if either the username or password is invalid the button remains disabled and the user is unable to login after correcting their username/password.
## Changes
- If authentication returns a 404 error, set `this.authenticating` to false
- Pass `invalidAuth` to the component. Necessary for the [companion PR](https://github.com/CenterForOpenScience/exp-addons/pull/159), which will disable the continue button when the invalidAuth modal is open 
