### PR TITLE
Fix warning about binding style attribute [LEI-252]

### DIFF
--- a/app/components/progress-bar/component.js
+++ b/app/components/progress-bar/component.js
@@ -4,6 +4,6 @@ export default Ember.Component.extend({
   pageNumber: null,
   width: Ember.computed('pageNumber', function() {
     var width = (this.pageNumber / 11) * 100;
-    return `${width}%`;
+    return new Ember.Handlebars.SafeString('width: ' + width + '%;');
   })
 });

--- a/app/components/progress-bar/template.hbs
+++ b/app/components/progress-bar/template.hbs
@@ -6,7 +6,7 @@
                aria-valuenow="0"
                aria-valuemin="0"
                aria-valuemax="100"
-               style="width: {{width}};">
+               style={{width}}>
           </div>
         </div>
         <div class="progress-text">{{t 'global.progress'}}</div>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-252
## Purpose

Fix warning in progress-bar test "Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped." 
## Summary of changes

Make the width computed return a safe string:
http://discuss.emberjs.com/t/binding-style-attributes-warning-still-popping-up-with-safe-string/7798
