### PR TITLE
Remove setting exp condition on session [LEI-262]

### DIFF
--- a/app/routes/participate/survey.js
+++ b/app/routes/participate/survey.js
@@ -9,14 +9,6 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
   store: Ember.inject.service(),
   currentUser: Ember.inject.service(),
 
-  _getCondition(profileId) {
-    var participantId = profileId.split('.')[1];
-    var id = participantId.split('_')[1];
-    if (id % 2 === 0) {
-      return '7pm';
-    }
-    return '10am';
-  },
   _getExperiment() {
     return this.store.find('experiment', config.studyId);
   },
@@ -47,7 +39,6 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
           }
           this.set('_experiment', experiment);
           session.set('experimentVersion', '');
-          session.set('experimentCondition', this._getCondition(session.get('profileId')));
           session.set('locale', this.controllerFor('participate').get('locale'));
           session.set('studyId', this.controllerFor('participate').get('studyId'));
           session.save().then(() => {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-262
## Purpose

Instead of showing a participant one of two conditions based on their participantID, they will be asked what time they experienced the situation so it is no longer necessary to store this information on the session.
## Summary of changes
- Don't set `experimentCondition` on the session
## Testing notes

Requires https://github.com/CenterForOpenScience/exp-addons/pull/172 to be merged first since it removes getting the `experimentCondition` in `exp-free-response` and `exp-rating-form`
