### PR TITLE
Remove isp-login class [LEI-278]

### DIFF
--- a/app/components/isp-jam-auth/template.hbs
+++ b/app/components/isp-jam-auth/template.hbs
@@ -13,7 +13,7 @@
         </div>
       </div>
       <div class="form-group">
-        <button disabled={{disableLogin}} class="btn isp-login btn-primary" onclick={{action 'authenticate'}}>{{t 'global.continueLabel'}}</button>
+        <button disabled={{disableLogin}} class="btn btn-primary" onclick={{action 'authenticate'}}>{{t 'global.continueLabel'}}</button>
           {{#if authenticating}}
               <i class="fa fa-spinner fa-lg fa-spin" aria-hidden="true"></i>
               <span class="sr-only">Logging in</span>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,6 +1,5 @@
 @import "components/progress-bar";
 @import "components/results-page";
-@import "components/isp-jam-auth";
 @import "components/language-picker";
 
 

--- a/app/styles/components/isp-jam-auth.scss
+++ b/app/styles/components/isp-jam-auth.scss
@@ -1,3 +1,0 @@
-.btn.isp-login {
-  margin-bottom: 0px;
-}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-278
## Purpose

The global btn class override that added a margin-bottom to all buttons was removed from exp-addons, so the isp-login class setting margin-bottom: 0 is no longer needed.
