### PR TITLE
Fix getting BFI answers on results page [LEI-234]

### DIFF
--- a/app/components/results-page/component.js
+++ b/app/components/results-page/component.js
@@ -1,12 +1,5 @@
 import Ember from 'ember';
 
-var VALUES = {
- 'disagreeStrongly': 1,
- 'disagree': 2,
- 'neutral': 3,
- 'agree': 4,
- 'agreeStrongly': 5
-};
 
 function averageScores(questions, reversed, items) {
   var total = score(questions, items) + reverseScore(reversed, items);
@@ -17,8 +10,8 @@ function score(questions, items) {
   var total = 0;
   for (var i=0; i < questions.length; i++) {
     var question = questions[i];
-    var value = items[question - 1];
-    total += VALUES[value];
+    var key = 'BFI' + question;
+    total += items[key];
   }
   return total;
 }
@@ -27,8 +20,8 @@ function reverseScore(questions, items) {
   var total = 0;
   for (var i=0; i < questions.length; i++) {
     var question = questions[i];
-    var value = items[question - 1];
-    total += (6 - VALUES[value]);
+    var key = 'BFI' + question;
+    total += (6 - items[key]);
   }
   return total;
 }


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-234
## Purpose

Fix how the results page gets the responses to the BFI questions from `session.expData` since the rating form data serialization changed.
## Testing notes

On the `exp-rating` component (the section after the cardsort), answer the question ("Please rate the extent to which you agree or disagree with the following statements: I am someone who...) and at the end of the survey, click to view personality results. There should be a score next to each personality trait. 
## Note

This PR should get merged after https://github.com/CenterForOpenScience/exp-addons/pull/182
