### PR TITLE
Add version number to consent form [LEI-287]

### DIFF
--- a/app/components/isp-consent-form/consentText.js
+++ b/app/components/isp-consent-form/consentText.js
@@ -7,6 +7,7 @@ export default {
             "All of your responses will be confidential and identified only by a number (and not by your name).  For research purposes, these anonymous data may be archived in an online database. Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty of any sort.  The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts.  There are no known risks.",
             "If you have any questions about this study or your rights as a participant, you may contact [local collaborator's name, email and affiliation], who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
         ],
-        "title": "Consent to Participate in Research"
+        "title": "Consent to Participate in Research",
+        "versionHistory": "(Consent form version: 14 October 2016)"
     }
 };

--- a/app/components/isp-consent-form/template.hbs
+++ b/app/components/isp-consent-form/template.hbs
@@ -14,4 +14,7 @@
     {{content.buttonLabel}}
   </button>
   </div>
+  {{#if content.versionHistory}}
+    <p>{{content.versionHistory}}</p>
+  {{/if}}
 </div>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-287
## Purpose

Add version number to consent form (required for the IRB)
## Summary of changes

If a site's consent form content includes a `versionHistory`, add it to the bottom of the consent form:  
![screen shot 2016-10-27 at 3 51 47 pm](https://cloud.githubusercontent.com/assets/6414394/19782831/8cd4565c-9c5d-11e6-8100-fb9ef4003983.png)
