### PR TITLE
Feature: Fix redirect to exit route [LEI-292]

### DIFF
--- a/app/routes/participate/survey/index.js
+++ b/app/routes/participate/survey/index.js
@@ -19,8 +19,8 @@ export default Ember.Route.extend({
 
       if (frameIndex !== 0) {
         this.replaceWith('participate.survey.index');
-        // Disable back button in qsort page 2, and rating-form page 1
-        if (!(frameIndex === 2 && framePage === 1) && frameIndex !== 3) {
+        // Disable back button in qsort page 2, rating-form page 1, and thank-you page
+        if (!(frameIndex === 2 && framePage === 1) && frameIndex !== 3 && frameIndex !== 4) {
           this.controllerFor('participate.survey.index').set('frameIndex', frameIndex - 1);
         }
         // Update pages within the rating-form

--- a/app/routes/participate/survey/index.js
+++ b/app/routes/participate/survey/index.js
@@ -10,13 +10,13 @@ export default Ember.Route.extend({
   actions: {
     willTransition(transition) {
       this._super(transition);
-
-      if (transition.targetName === 'participate.survey.results') {
+      if (transition.targetName === 'participate.survey.results' || transition.targetName === 'exit') {
         return true;
       }
 
       var frameIndex = this.controllerFor('participate.survey.index').get('frameIndex');
       var framePage = this.controllerFor('participate.survey.index').get('framePage');
+
       if (frameIndex !== 0) {
         this.replaceWith('participate.survey.index');
         // Disable back button in qsort page 2, and rating-form page 1


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-292

## Purpose
- When a user clicks the "Exit study" button on the exp-thank-you page, they were getting redirected to the consent form instead of the exit study route.
- When a user is on the exp-thank-you page and clicks the back button, they are taken to the first page of the rating form survey. Instead, they should not be able to go back.

## Summary of changes
- Return true from `willTransition` if transitioning to the exit route.
- Disable the back-button for the exp-thank-you page

## Testing notes
 - On the exp-thank-you page, click the "Exit study" button. It should redirect to a page that says "Thank you for your participation! Your responses have been recorded."
- On the exp-thank-you page, click the back button. It should not redirect to a different page.
