### PR TITLE
Add consent form data for test2 study id [LEI-290]

### DIFF
--- a/app/components/isp-consent-form/consentText.js
+++ b/app/components/isp-consent-form/consentText.js
@@ -9,5 +9,17 @@ export default {
         ],
         "title": "Consent to Participate in Research",
         "versionHistory": "(Consent form version: 14 October 2016)"
+    },
+    "test2": {
+        "buttonLabel": "Test2 button label",
+        "consentLabel": "Test2 consent label",
+        "paragraphs": [
+            "Test2 paragraph 1 Test2 paragraph 1 Test2 paragraph 1.",
+            "Test2 paragraph 2 Test2 paragraph 2 Test2 paragraph 2.",
+            "Test2 paragraph 3 Test2 paragraph 3 Test2 paragraph 3.",
+            "Test2 paragraph 4 Test2 paragraph 4 Test2 paragraph 4."
+        ],
+        "title": "Test2 Consent Form Title",
+        "versionHistory": "(Test2 Consent form version: 31 October 2016)"
     }
 };


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-290

## Purpose
In order to test that the consent form text varies depending on the study id, add in test data for a second test site/study_id.


## Testing Notes
Login to ISP with an account that has the study id "test2" and see that the consent form text is different than the "test" account.