### PR TITLE
Add pseudo locale for testing [LEI-290]

### DIFF
--- a/app/components/language-picker/countries.js
+++ b/app/components/language-picker/countries.js
@@ -648,5 +648,15 @@ export default [
             }
         ],
         "name": "Vietnam"
+    },
+    {
+        "code": "US",
+        "languages": [
+            {
+                "code": "test",
+                "name": "Test"
+            }
+        ],
+        "name": "X-Pseudo"
     }
 ];

--- a/app/locales/test/config.js
+++ b/app/locales/test/config.js
@@ -1,0 +1,16 @@
+// Ember-I18n includes configuration for common locales. Most users
+// can safely delete this file. Use it if you need to override behavior
+// for a locale or define behavior for a locale that Ember-I18n
+// doesn't know about.
+export default {
+  // rtl: [true|FALSE],
+  //
+  // pluralForm: function(count) {
+  //   if (count === 0) { return 'zero'; }
+  //   if (count === 1) { return 'one'; }
+  //   if (count === 2) { return 'two'; }
+  //   if (count < 5) { return 'few'; }
+  //   if (count >= 5) { return 'many'; }
+  //   return 'other';
+  // }
+};

--- a/app/locales/test/translations.js
+++ b/app/locales/test/translations.js
@@ -1,0 +1,1096 @@
+const translations = {
+    "0": "0",
+    "1": "1",
+    "10": "10",
+    "100": "100",
+    "11": "11",
+    "12": "12",
+    "13": "13",
+    "14": "14",
+    "15": "15",
+    "16": "16",
+    "17": "17",
+    "18": "18",
+    "19": "19",
+    "2": "2",
+    "20": "20",
+    "21": "21",
+    "22": "22",
+    "23": "23",
+    "24": "24",
+    "25": "25",
+    "26": "26",
+    "27": "27",
+    "28": "28",
+    "29": "29",
+    "3": "3",
+    "30": "30",
+    "31": "31",
+    "32": "32",
+    "33": "33",
+    "34": "34",
+    "35": "35",
+    "36": "36",
+    "37": "37",
+    "38": "38",
+    "39": "39",
+    "4": "4",
+    "40": "40",
+    "41": "41",
+    "42": "42",
+    "43": "43",
+    "44": "44",
+    "45": "45",
+    "46": "46",
+    "47": "47",
+    "48": "48",
+    "49": "49",
+    "5": "5",
+    "50": "50",
+    "51": "51",
+    "52": "52",
+    "53": "53",
+    "54": "54",
+    "55": "55",
+    "56": "56",
+    "57": "57",
+    "58": "58",
+    "59": "59",
+    "6": "6",
+    "60": "60",
+    "61": "61",
+    "62": "62",
+    "63": "63",
+    "64": "64",
+    "65": "65",
+    "66": "66",
+    "67": "67",
+    "68": "68",
+    "69": "69",
+    "7": "7",
+    "70": "70",
+    "71": "71",
+    "72": "72",
+    "73": "73",
+    "74": "74",
+    "75": "75",
+    "76": "76",
+    "77": "77",
+    "78": "78",
+    "79": "79",
+    "8": "8",
+    "80": "80",
+    "81": "81",
+    "82": "82",
+    "83": "83",
+    "84": "84",
+    "85": "85",
+    "86": "86",
+    "87": "87",
+    "88": "88",
+    "89": "89",
+    "9": "9",
+    "90": "90",
+    "91": "91",
+    "92": "92",
+    "93": "93",
+    "94": "94",
+    "95": "95",
+    "96": "96",
+    "97": "97",
+    "98": "98",
+    "99": "99",
+    "Key": "EnglishENGLISH",
+    "consent": {
+        "button": {
+            "labelUnaccepted": "Please accept terms to continuePLEASE ACCEPT TERMS TO CONTINUE"
+        },
+        "checkboxLabel": "I have read and understand the above statements and agree to participate.I HAVE READ AND UNDERSTAND THE ABOVE STATEMENTS AND AGREE TO PARTICIPATE.",
+        "firstSection": "Welcome to our research study.  Your participation will be in one session and will take less than one hour. You will be asked to describe a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes.  At the end of the study, if you choose, you will receive personalized information about your personality.WELCOME TO OUR RESEARCH STUDY.  YOUR PARTICIPATION WILL BE IN ONE SESSION AND WILL TAKE LESS THAN ONE HOUR. YOU WILL BE ASKED TO DESCRIBE A SITUATION YOU EXPERIENCED RECENTLY AND YOUR BEHAVIORS IN IT. YOU WILL ALSO BE ASKED SOME QUESTIONS ABOUT YOUR VALUES AND ATTITUDES.  AT THE END OF THE STUDY, IF YOU CHOOSE, YOU WILL RECEIVE PERSONALIZED INFORMATION ABOUT YOUR PERSONALITY.",
+        "secondSection": "All of your responses will be confidential and identified only by a number (and not by your name).  For research purposes, these anonymous data may be archived in an online database. Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty of any sort.  The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts.  There are no known risks.ALL OF YOUR RESPONSES WILL BE CONFIDENTIAL AND IDENTIFIED ONLY BY A NUMBER (AND NOT BY YOUR NAME).  FOR RESEARCH PURPOSES, THESE ANONYMOUS DATA MAY BE ARCHIVED IN AN ONLINE DATABASE. EACH QUESTION MUST BE ANSWERED IN ORDER TO COMPLETE THIS SURVEY, BUT YOU CAN DISCONTINUE YOUR PARTICIPATION AT ANY TIME WITHOUT PENALTY OF ANY SORT.  THE POTENTIAL BENEFITS OF THIS RESEARCH INCLUDE IMPROVING THE UNDERSTANDING OF PERSONS AND THEIR LIVES ACROSS CULTURAL CONTEXTS.  THERE ARE NO KNOWN RISKS.",
+        "thirdSection": "If you have any questions about this study or your rights as a participant, you may contact [local collaborator\u2019s name, email and affiliation], who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation.IF YOU HAVE ANY QUESTIONS ABOUT THIS STUDY OR YOUR RIGHTS AS A PARTICIPANT, YOU MAY CONTACT [LOCAL COLLABORATOR\u2019S NAME, EMAIL AND AFFILIATION], WHO IS RESPONSIBLE FOR DATA COLLECTION AT YOUR LOCATION, OR THE UNIVERSITY OF CALIFORNIA, RIVERSIDE, OFFICE OF RESEARCH INTEGRITY BY EMAIL AT IRB@UCR.EDU. WE SINCERELY APPRECIATE YOUR COOPERATION.",
+        "title": "Consent to Participate in ResearchCONSENT TO PARTICIPATE IN RESEARCH",
+        "versionHistory": "(Consent form version: 14 October 2016)(CONSENT FORM VERSION: 14 OCTOBER 2016)"
+    },
+    "exitpage": {
+        "line1": "Thank you for your participation!THANK YOU FOR YOUR PARTICIPATION!",
+        "line2": "Your responses have been recorded.YOUR RESPONSES HAVE BEEN RECORDED."
+    },
+    "feedback": {
+        "agree": "AgreeablenessAGREEABLENESS",
+        "consc": "ConscientiousnessCONSCIENTIOUSNESS",
+        "exitButton": "ExitEXIT",
+        "extra": "ExtraversionEXTRAVERSION",
+        "firstSection": "Based on decades of research, personality researchers agree that the most important individual differences in personality traits are described by five basic traits known as the \u201cBig Five\u201d: Extraversion, Agreeableness, Conscientiousness, Emotional Stability, and Openness to Experience. The measures you just completed provide scores on each of these traits and your results are described below.BASED ON DECADES OF RESEARCH, PERSONALITY RESEARCHERS AGREE THAT THE MOST IMPORTANT INDIVIDUAL DIFFERENCES IN PERSONALITY TRAITS ARE DESCRIBED BY FIVE BASIC TRAITS KNOWN AS THE \u201cBIG FIVE\u201d: EXTRAVERSION, AGREEABLENESS, CONSCIENTIOUSNESS, EMOTIONAL STABILITY, AND OPENNESS TO EXPERIENCE. THE MEASURES YOU JUST COMPLETED PROVIDE SCORES ON EACH OF THESE TRAITS AND YOUR RESULTS ARE DESCRIBED BELOW.",
+        "fourthSection": "Thank you for your participation!THANK YOU FOR YOUR PARTICIPATION!",
+        "hiAgree": "High scorers tend to be considerate and polite in social interactions, and enjoy cooperating with others. They find it easy to trust people, and feel compassion for those in need. High scorers tend to be well liked by their peers, and they establish satisfying and stable close relationships. They are more likely to be religious, to serve in community leadership roles, and to do volunteer work. Older adults tend to score higher than younger adults.HIGH SCORERS TEND TO BE CONSIDERATE AND POLITE IN SOCIAL INTERACTIONS, AND ENJOY COOPERATING WITH OTHERS. THEY FIND IT EASY TO TRUST PEOPLE, AND FEEL COMPASSION FOR THOSE IN NEED. HIGH SCORERS TEND TO BE WELL LIKED BY THEIR PEERS, AND THEY ESTABLISH SATISFYING AND STABLE CLOSE RELATIONSHIPS. THEY ARE MORE LIKELY TO BE RELIGIOUS, TO SERVE IN COMMUNITY LEADERSHIP ROLES, AND TO DO VOLUNTEER WORK. OLDER ADULTS TEND TO SCORE HIGHER THAN YOUNGER ADULTS.",
+        "hiConsc": "High scorers tend to be organized and responsible. They work hard to achieve their goals, and complete tasks they have begun. High scorers tend to earn higher grades in school, and perform better in many occupations. They are more likely to be religious and hold conservative political attitudes. They tend to exercise more, have better physical health, and live longer. Older adults tend to score higher than younger adults.HIGH SCORERS TEND TO BE ORGANIZED AND RESPONSIBLE. THEY WORK HARD TO ACHIEVE THEIR GOALS, AND COMPLETE TASKS THEY HAVE BEGUN. HIGH SCORERS TEND TO EARN HIGHER GRADES IN SCHOOL, AND PERFORM BETTER IN MANY OCCUPATIONS. THEY ARE MORE LIKELY TO BE RELIGIOUS AND HOLD CONSERVATIVE POLITICAL ATTITUDES. THEY TEND TO EXERCISE MORE, HAVE BETTER PHYSICAL HEALTH, AND LIVE LONGER. OLDER ADULTS TEND TO SCORE HIGHER THAN YOUNGER ADULTS.",
+        "hiExtra": "High scorers tend to be talkative and energetic. They like being around people, and are comfortable asserting themselves in a group. High scorers tend to have more friends and dating partners, and are seen as more popular. They are more likely to serve in community leadership roles, and to do volunteer work. They tend to prefer energetic music, exercise more frequently, and are more likely to play a sport. They experience more frequent positive emotions, and react more strongly to positive events.HIGH SCORERS TEND TO BE TALKATIVE AND ENERGETIC. THEY LIKE BEING AROUND PEOPLE, AND ARE COMFORTABLE ASSERTING THEMSELVES IN A GROUP. HIGH SCORERS TEND TO HAVE MORE FRIENDS AND DATING PARTNERS, AND ARE SEEN AS MORE POPULAR. THEY ARE MORE LIKELY TO SERVE IN COMMUNITY LEADERSHIP ROLES, AND TO DO VOLUNTEER WORK. THEY TEND TO PREFER ENERGETIC MUSIC, EXERCISE MORE FREQUENTLY, AND ARE MORE LIKELY TO PLAY A SPORT. THEY EXPERIENCE MORE FREQUENT POSITIVE EMOTIONS, AND REACT MORE STRONGLY TO POSITIVE EVENTS.",
+        "hiNeurot": "High scorers tend to be emotionally stable and resilient. They usually stay calm, even in stressful situations, and can quickly bounce back from negative events. People who score high on emotional stability tend to feel a greater sense of well-being.HIGH SCORERS TEND TO BE EMOTIONALLY STABLE AND RESILIENT. THEY USUALLY STAY CALM, EVEN IN STRESSFUL SITUATIONS, AND CAN QUICKLY BOUNCE BACK FROM NEGATIVE EVENTS. PEOPLE WHO SCORE HIGH ON EMOTIONAL STABILITY TEND TO FEEL A GREATER SENSE OF WELL-BEING.",
+        "hiOpen": "High scorers are generally open to new activities and new ideas. They tend to be creative, intellectually curious, and sensitive to art and beauty. High scorers tend to prefer, and do better in, scientific and artistic occupations. They prefer classical, jazz, blues, and rock music.HIGH SCORERS ARE GENERALLY OPEN TO NEW ACTIVITIES AND NEW IDEAS. THEY TEND TO BE CREATIVE, INTELLECTUALLY CURIOUS, AND SENSITIVE TO ART AND BEAUTY. HIGH SCORERS TEND TO PREFER, AND DO BETTER IN, SCIENTIFIC AND ARTISTIC OCCUPATIONS. THEY PREFER CLASSICAL, JAZZ, BLUES, AND ROCK MUSIC.",
+        "labels": {
+            "high": "HighHIGH",
+            "low": "LowLOW",
+            "medium": "MediumMEDIUM"
+        },
+        "loAgree": "Low scorers express themselves directly and bluntly, even at the risk of starting an argument. They enjoy competition, and tend to be skeptical of other people's intentions. Low scorers tend to earn higher salaries, and are more likely to engage in some risky behaviors, such as smoking and aggressive driving.LOW SCORERS EXPRESS THEMSELVES DIRECTLY AND BLUNTLY, EVEN AT THE RISK OF STARTING AN ARGUMENT. THEY ENJOY COMPETITION, AND TEND TO BE SKEPTICAL OF OTHER PEOPLE'S INTENTIONS. LOW SCORERS TEND TO EARN HIGHER SALARIES, AND ARE MORE LIKELY TO ENGAGE IN SOME RISKY BEHAVIORS, SUCH AS SMOKING AND AGGRESSIVE DRIVING.",
+        "loConsc": "Low scorers tend to act spontaneously rather than making plans, and find it easier to look at the big picture than pay attention to details. They prefer to jump between tasks, instead of finishing one at a time. They tend to engage in more risky behaviors, such as smoking, alcohol consumption, and drug use.LOW SCORERS TEND TO ACT SPONTANEOUSLY RATHER THAN MAKING PLANS, AND FIND IT EASIER TO LOOK AT THE BIG PICTURE THAN PAY ATTENTION TO DETAILS. THEY PREFER TO JUMP BETWEEN TASKS, INSTEAD OF FINISHING ONE AT A TIME. THEY TEND TO ENGAGE IN MORE RISKY BEHAVIORS, SUCH AS SMOKING, ALCOHOL CONSUMPTION, AND DRUG USE.",
+        "loExtra": "Low scorers tend to be socially and emotionally reserved. They generally prefer to be alone or with a few close friends, and keep their opinions and feelings to themselves. They are less likely to engage in thrill-seeking activities or risky behaviors such as smoking and alcohol consumption.LOW SCORERS TEND TO BE SOCIALLY AND EMOTIONALLY RESERVED. THEY GENERALLY PREFER TO BE ALONE OR WITH A FEW CLOSE FRIENDS, AND KEEP THEIR OPINIONS AND FEELINGS TO THEMSELVES. THEY ARE LESS LIKELY TO ENGAGE IN THRILL-SEEKING ACTIVITIES OR RISKY BEHAVIORS SUCH AS SMOKING AND ALCOHOL CONSUMPTION.",
+        "loNeurot": "Low scorers tend to be emotionally sensitive, and have up-and-down mood swings. They experience more frequent negative emotions, and react more strongly to negative events. Younger adults tend to score lower than older adults.LOW SCORERS TEND TO BE EMOTIONALLY SENSITIVE, AND HAVE UP-AND-DOWN MOOD SWINGS. THEY EXPERIENCE MORE FREQUENT NEGATIVE EMOTIONS, AND REACT MORE STRONGLY TO NEGATIVE EVENTS. YOUNGER ADULTS TEND TO SCORE LOWER THAN OLDER ADULTS.",
+        "loOpen": "Low scorers tend to be traditional, practical, and like to stick with traditional ways of doing things. They prefer the familiar over the new, and the concrete over the abstract. Low scorers tend to prefer, and do better in, conventional and practical occupations such as crafts and trades.LOW SCORERS TEND TO BE TRADITIONAL, PRACTICAL, AND LIKE TO STICK WITH TRADITIONAL WAYS OF DOING THINGS. THEY PREFER THE FAMILIAR OVER THE NEW, AND THE CONCRETE OVER THE ABSTRACT. LOW SCORERS TEND TO PREFER, AND DO BETTER IN, CONVENTIONAL AND PRACTICAL OCCUPATIONS SUCH AS CRAFTS AND TRADES.",
+        "neurot": "Emotional StabilityEMOTIONAL STABILITY",
+        "open": "Openness to ExperienceOPENNESS TO EXPERIENCE",
+        "score": "Your score out of 100 possible:YOUR SCORE OUT OF 100 POSSIBLE:",
+        "secondSection": "On each trait, scores above 60 can be considered high, and scores below 40 can be considered low. Descriptions of high and low scorers appear below. If your score is between 40 and 60, then your personality would probably be described as about average on the attributes listed.ON EACH TRAIT, SCORES ABOVE 60 CAN BE CONSIDERED HIGH, AND SCORES BELOW 40 CAN BE CONSIDERED LOW. DESCRIPTIONS OF HIGH AND LOW SCORERS APPEAR BELOW. IF YOUR SCORE IS BETWEEN 40 AND 60, THEN YOUR PERSONALITY WOULD PROBABLY BE DESCRIBED AS ABOUT AVERAGE ON THE ATTRIBUTES LISTED.",
+        "thirdSection": "We hope you enjoyed your participation in this study.WE HOPE YOU ENJOYED YOUR PARTICIPATION IN THIS STUDY.",
+        "title": "Your PersonalityYOUR PERSONALITY"
+    },
+    "flag": {
+        "chooseLanguage": "Please choose a languagePLEASE CHOOSE A LANGUAGE"
+    },
+    "global": {
+        "agreement": {
+            "agree": "AgreeAGREE",
+            "agreeStrongly": "Agree stronglyAGREE STRONGLY",
+            "disagree": "DisagreeDISAGREE",
+            "disagreeStrongly": "Disagree stronglyDISAGREE STRONGLY",
+            "neutral": "Neutral; no opinionNEUTRAL; NO OPINION"
+        },
+        "char": {
+            "extremelyChar": "Extremely CharacteristicEXTREMELY CHARACTERISTIC",
+            "extremelyUnchar": "Extremely UncharacteristicEXTREMELY UNCHARACTERISTIC",
+            "fairlyChar": "Fairly CharacteristicFAIRLY CHARACTERISTIC",
+            "fairlyUnchar": "Fairly UncharacteristicFAIRLY UNCHARACTERISTIC",
+            "neutral": "Neither Characteristic nor UncharacteristicNEITHER CHARACTERISTIC NOR UNCHARACTERISTIC",
+            "quiteChar": "Quite CharacteristicQUITE CHARACTERISTIC",
+            "quiteUnchar": "Quite UncharacteristicQUITE UNCHARACTERISTIC",
+            "somewhatChar": "Somewhat CharacteristicSOMEWHAT CHARACTERISTIC",
+            "somewhatUnchar": "Somewhat UncharacteristicSOMEWHAT UNCHARACTERISTIC"
+        },
+        "continueLabel": "ContinueCONTINUE",
+        "describe": {
+            "aGreatDeal": "A great dealA GREAT DEAL",
+            "aLittle": "A littleA LITTLE",
+            "notAtAll": "Not at allNOT AT ALL"
+        },
+        "noLabel": "NoNO",
+        "previousLabel": "Previous PagePREVIOUS PAGE",
+        "progress": "ProgressPROGRESS",
+        "selectUnselected": "Please selectPLEASE SELECT",
+        "yesLabel": "YesYES"
+    },
+    "login": {
+        "changeButton": "Change languageCHANGE LANGUAGE",
+        "participantID": "Participant IDPARTICIPANT ID",
+        "studyID": "Study IDSTUDY ID",
+        "youChose": "You chose:YOU CHOSE:"
+    },
+    "measures": {
+        "questions": {
+            "1": {
+                "label": "Overall, was the situation you described a positive experience or a negative experience?OVERALL, WAS THE SITUATION YOU DESCRIBED A POSITIVE EXPERIENCE OR A NEGATIVE EXPERIENCE?",
+                "options": {
+                    "extremelyNeg": "Extremely negativeEXTREMELY NEGATIVE",
+                    "extremelyPos": "Extremely positiveEXTREMELY POSITIVE",
+                    "fairlyNeg": "Fairly negativeFAIRLY NEGATIVE",
+                    "fairlyPos": "Fairly positiveFAIRLY POSITIVE",
+                    "neither": "Neither negative nor positiveNEITHER NEGATIVE NOR POSITIVE",
+                    "quiteNeg": "Quite negativeQUITE NEGATIVE",
+                    "quitePos": "Quite positiveQUITE POSITIVE",
+                    "somewhatNeg": "Somewhat negativeSOMEWHAT NEGATIVE",
+                    "somewhatPos": "Somewhat positiveSOMEWHAT POSITIVE"
+                }
+            },
+            "10": {
+                "items": {
+                    "1": {
+                        "label": "There are many social norms that people are supposed to abide by in this country.THERE ARE MANY SOCIAL NORMS THAT PEOPLE ARE SUPPOSED TO ABIDE BY IN THIS COUNTRY."
+                    },
+                    "2": {
+                        "label": "In this country, there are very clear expectations for how people should act in most situations.IN THIS COUNTRY, THERE ARE VERY CLEAR EXPECTATIONS FOR HOW PEOPLE SHOULD ACT IN MOST SITUATIONS."
+                    },
+                    "3": {
+                        "label": "People agree upon what behaviors are appropriate versus inappropriate in most situations in this country.PEOPLE AGREE UPON WHAT BEHAVIORS ARE APPROPRIATE VERSUS INAPPROPRIATE IN MOST SITUATIONS IN THIS COUNTRY."
+                    },
+                    "4": {
+                        "label": "People in this country have a great deal of freedom in deciding how they want to behave in most situations.PEOPLE IN THIS COUNTRY HAVE A GREAT DEAL OF FREEDOM IN DECIDING HOW THEY WANT TO BEHAVE IN MOST SITUATIONS."
+                    },
+                    "5": {
+                        "label": "In this country, if someone acts in an inappropriate way, others will strongly disapprove.IN THIS COUNTRY, IF SOMEONE ACTS IN AN INAPPROPRIATE WAY, OTHERS WILL STRONGLY DISAPPROVE."
+                    },
+                    "6": {
+                        "label": "People in this country almost always comply with social norms.PEOPLE IN THIS COUNTRY ALMOST ALWAYS COMPLY WITH SOCIAL NORMS."
+                    }
+                },
+                "label": "Please rate the extent to which you agree or disagree with the following statements:PLEASE RATE THE EXTENT TO WHICH YOU AGREE OR DISAGREE WITH THE FOLLOWING STATEMENTS:",
+                "options": {
+                    "agree": "AgreeAGREE",
+                    "agreeStrongly": "Agree stronglyAGREE STRONGLY",
+                    "disagree": "DisagreeDISAGREE",
+                    "disagreeStrongly": "Disagree stronglyDISAGREE STRONGLY",
+                    "neutral": "Neutral; no opinionNEUTRAL; NO OPINION"
+                }
+            },
+            "11": {
+                "label": "Is there an aspect of your personality that you\u2019re currently trying to change?IS THERE AN ASPECT OF YOUR PERSONALITY THAT YOU\u2019RE CURRENTLY TRYING TO CHANGE?",
+                "options": {
+                    "no": "NoNO",
+                    "yes": "YesYES"
+                }
+            },
+            "12": {
+                "label": "What aspect are you trying to change?WHAT ASPECT ARE YOU TRYING TO CHANGE?"
+            },
+            "13": {
+                "items": {
+                    "1": {
+                        "label": "Most people are basically honestMOST PEOPLE ARE BASICALLY HONEST"
+                    },
+                    "2": {
+                        "label": "Most people are basically good-natured and kindMOST PEOPLE ARE BASICALLY GOOD-NATURED AND KIND"
+                    },
+                    "3": {
+                        "label": "Most people trust othersMOST PEOPLE TRUST OTHERS"
+                    },
+                    "4": {
+                        "label": "Generally, I trust othersGENERALLY, I TRUST OTHERS"
+                    },
+                    "5": {
+                        "label": "Most people are trustworthyMOST PEOPLE ARE TRUSTWORTHY"
+                    }
+                },
+                "label": "Please rate the extent to which you agree or disagree with the following statements:PLEASE RATE THE EXTENT TO WHICH YOU AGREE OR DISAGREE WITH THE FOLLOWING STATEMENTS:",
+                "options": {
+                    "agree": "AgreeAGREE",
+                    "agreeStrongly": "Agree stronglyAGREE STRONGLY",
+                    "disagree": "DisagreeDISAGREE",
+                    "disagreeStrongly": "Disagree stronglyDISAGREE STRONGLY",
+                    "neutral": "Neutral; no opinionNEUTRAL; NO OPINION"
+                }
+            },
+            "14": {
+                "items": {
+                    "1": {
+                        "label": "In uncertain times, I usually expect the best.IN UNCERTAIN TIMES, I USUALLY EXPECT THE BEST."
+                    },
+                    "2": {
+                        "label": "If something can go wrong for me, it will.IF SOMETHING CAN GO WRONG FOR ME, IT WILL."
+                    },
+                    "3": {
+                        "label": "I'm always optimistic about my future.I'M ALWAYS OPTIMISTIC ABOUT MY FUTURE."
+                    },
+                    "4": {
+                        "label": "I hardly ever expect things to go my way.I HARDLY EVER EXPECT THINGS TO GO MY WAY."
+                    },
+                    "5": {
+                        "label": "I rarely count on good things happening to me.I RARELY COUNT ON GOOD THINGS HAPPENING TO ME."
+                    },
+                    "6": {
+                        "label": "Overall, I expect more good things to happen to me than bad.OVERALL, I EXPECT MORE GOOD THINGS TO HAPPEN TO ME THAN BAD."
+                    }
+                },
+                "label": "Please rate the extent to which you agree or disagree with the following statements:PLEASE RATE THE EXTENT TO WHICH YOU AGREE OR DISAGREE WITH THE FOLLOWING STATEMENTS:",
+                "options": {
+                    "agree": "AgreeAGREE",
+                    "agreeStrongly": "Agree stronglyAGREE STRONGLY",
+                    "disagree": "DisagreeDISAGREE",
+                    "disagreeStrongly": "Disagree stronglyDISAGREE STRONGLY",
+                    "neutral": "Neutral; no opinionNEUTRAL; NO OPINION"
+                }
+            },
+            "15": {
+                "items": {
+                    "1": {
+                        "label": "I wouldn't use flattery to get a raise or promotion at work, even if I thought it would succeed.I WOULDN'T USE FLATTERY TO GET A RAISE OR PROMOTION AT WORK, EVEN IF I THOUGHT IT WOULD SUCCEED."
+                    },
+                    "10": {
+                        "label": "I want people to know that I am an important person of high status.I WANT PEOPLE TO KNOW THAT I AM AN IMPORTANT PERSON OF HIGH STATUS."
+                    },
+                    "2": {
+                        "label": "If I want something from someone, I will laugh at that person's worst jokes.IF I WANT SOMETHING FROM SOMEONE, I WILL LAUGH AT THAT PERSON'S WORST JOKES."
+                    },
+                    "3": {
+                        "label": "I wouldn't pretend to like someone just to get that person to do favors for me.I WOULDN'T PRETEND TO LIKE SOMEONE JUST TO GET THAT PERSON TO DO FAVORS FOR ME."
+                    },
+                    "4": {
+                        "label": "If I knew that I could never get caught, I would be willing to steal a large sum of money.IF I KNEW THAT I COULD NEVER GET CAUGHT, I WOULD BE WILLING TO STEAL A LARGE SUM OF MONEY."
+                    },
+                    "5": {
+                        "label": "I would never accept a bribe, even if it were very large.I WOULD NEVER ACCEPT A BRIBE, EVEN IF IT WERE VERY LARGE."
+                    },
+                    "6": {
+                        "label": "I\u2019d be tempted to use counterfeit money, if I were sure I could get away with it.I\u2019D BE TEMPTED TO USE COUNTERFEIT MONEY, IF I WERE SURE I COULD GET AWAY WITH IT."
+                    },
+                    "7": {
+                        "label": "Having a lot of money is not especially important to me.HAVING A LOT OF MONEY IS NOT ESPECIALLY IMPORTANT TO ME."
+                    },
+                    "8": {
+                        "label": "I would get a lot of pleasure from owning expensive luxury goods.I WOULD GET A LOT OF PLEASURE FROM OWNING EXPENSIVE LUXURY GOODS."
+                    },
+                    "9": {
+                        "label": "I think that I am entitled to more respect than the average person is.I THINK THAT I AM ENTITLED TO MORE RESPECT THAN THE AVERAGE PERSON IS."
+                    }
+                },
+                "label": "Please rate the extent to which you agree or disagree with the following statements:PLEASE RATE THE EXTENT TO WHICH YOU AGREE OR DISAGREE WITH THE FOLLOWING STATEMENTS:",
+                "options": {
+                    "agree": "AgreeAGREE",
+                    "agreeStrongly": "Agree stronglyAGREE STRONGLY",
+                    "disagree": "DisagreeDISAGREE",
+                    "disagreeStrongly": "Disagree stronglyDISAGREE STRONGLY",
+                    "neutral": "Neutral; no opinionNEUTRAL; NO OPINION"
+                }
+            },
+            "16": {
+                "items": {
+                    "1": {
+                        "label": "With familyWITH FAMILY"
+                    },
+                    "2": {
+                        "label": "With friendsWITH FRIENDS"
+                    },
+                    "3": {
+                        "label": "In the city where I liveIN THE CITY WHERE I LIVE"
+                    },
+                    "4": {
+                        "label": "In societyIN SOCIETY"
+                    },
+                    "5": {
+                        "label": "In the worldIN THE WORLD"
+                    }
+                },
+                "label": "To what extent do you think your life develops in the following environments?TO WHAT EXTENT DO YOU THINK YOUR LIFE DEVELOPS IN THE FOLLOWING ENVIRONMENTS?",
+                "options": {
+                    "aLittle": "A littleA LITTLE",
+                    "completely": "CompletelyCOMPLETELY",
+                    "notAtAll": "Not at allNOT AT ALL",
+                    "quiteaBit": "Quite a bitQUITE A BIT"
+                }
+            },
+            "17": {
+                "items": {
+                    "1": {
+                        "label": "I deserve to be seen as a great person.I DESERVE TO BE SEEN AS A GREAT PERSON."
+                    },
+                    "2": {
+                        "label": "Being a very special person gives me a lot of strength.BEING A VERY SPECIAL PERSON GIVES ME A LOT OF STRENGTH."
+                    },
+                    "3": {
+                        "label": "I manage to be the center of attention with my outstanding contributions.I MANAGE TO BE THE CENTER OF ATTENTION WITH MY OUTSTANDING CONTRIBUTIONS."
+                    },
+                    "4": {
+                        "label": "Most people are somehow losers.MOST PEOPLE ARE SOMEHOW LOSERS."
+                    },
+                    "5": {
+                        "label": "I want my rivals to fail.I WANT MY RIVALS TO FAIL."
+                    },
+                    "6": {
+                        "label": "I react annoyed if another person steals the show from me.I REACT ANNOYED IF ANOTHER PERSON STEALS THE SHOW FROM ME."
+                    }
+                },
+                "label": "Please rate the extent to which you agree or disagree with the following statements:PLEASE RATE THE EXTENT TO WHICH YOU AGREE OR DISAGREE WITH THE FOLLOWING STATEMENTS:",
+                "options": {
+                    "agree": "AgreeAGREE",
+                    "agreeStrongly": "Agree stronglyAGREE STRONGLY",
+                    "disagree": "DisagreeDISAGREE",
+                    "disagreeStrongly": "Disagree stronglyDISAGREE STRONGLY",
+                    "neutral": "Neutral; no opinionNEUTRAL; NO OPINION"
+                }
+            },
+            "18": {
+                "label": "How successful have you been in changing this aspect of your personality?HOW SUCCESSFUL HAVE YOU BEEN IN CHANGING THIS ASPECT OF YOUR PERSONALITY?",
+                "options": {
+                    "alittleSuccessful": "A little successfulA LITTLE SUCCESSFUL",
+                    "completelySuccessful": "Completely successfulCOMPLETELY SUCCESSFUL",
+                    "moderatelySuccessful": "Moderately successfulMODERATELY SUCCESSFUL",
+                    "notatallSuccessful": "Not at all successfulNOT AT ALL SUCCESSFUL",
+                    "verySuccessful": "Very successfulVERY SUCCESSFUL"
+                }
+            },
+            "2": {
+                "label": "How often do you experience situations similar to the one you just described?HOW OFTEN DO YOU EXPERIENCE SITUATIONS SIMILAR TO THE ONE YOU JUST DESCRIBED?",
+                "options": {
+                    "hardlyEver": "Hardly everHARDLY EVER",
+                    "never": "NeverNEVER",
+                    "occasionally": "OccasionallyOCCASIONALLY",
+                    "quiteOften": "Quite oftenQUITE OFTEN"
+                }
+            },
+            "3": {
+                "items": {
+                    "1": {
+                        "label": "I tried to control the situation.I TRIED TO CONTROL THE SITUATION."
+                    },
+                    "10": {
+                        "label": "I was physically animated, moved around.I WAS PHYSICALLY ANIMATED, MOVED AROUND."
+                    },
+                    "11": {
+                        "label": "I was interested in what someone had to say.I WAS INTERESTED IN WHAT SOMEONE HAD TO SAY."
+                    },
+                    "12": {
+                        "label": "I sought advice.I SOUGHT ADVICE."
+                    },
+                    "13": {
+                        "label": "I acted playfully.I ACTED PLAYFULLY."
+                    },
+                    "14": {
+                        "label": "I expressed self-pity or feelings of victimization.I EXPRESSED SELF-PITY OR FEELINGS OF VICTIMIZATION."
+                    },
+                    "15": {
+                        "label": "I spoke in a loud voice.I SPOKE IN A LOUD VOICE."
+                    },
+                    "16": {
+                        "label": "I exhibited a high degree of intelligence.I EXHIBITED A HIGH DEGREE OF INTELLIGENCE."
+                    },
+                    "2": {
+                        "label": "I said negative things about myself.I SAID NEGATIVE THINGS ABOUT MYSELF."
+                    },
+                    "3": {
+                        "label": "I behaved in a competitive manner.I BEHAVED IN A COMPETITIVE MANNER."
+                    },
+                    "4": {
+                        "label": "I displayed ambition.I DISPLAYED AMBITION."
+                    },
+                    "5": {
+                        "label": "I dominated the situation.I DOMINATED THE SITUATION."
+                    },
+                    "6": {
+                        "label": "I showed high enthusiasm and a high energy level.I SHOWED HIGH ENTHUSIASM AND A HIGH ENERGY LEVEL."
+                    },
+                    "7": {
+                        "label": "I engaged in physical activity.I ENGAGED IN PHYSICAL ACTIVITY."
+                    },
+                    "8": {
+                        "label": "I concentrated on or worked hard at a task.I CONCENTRATED ON OR WORKED HARD AT A TASK."
+                    },
+                    "9": {
+                        "label": "I was reserved and unexpressive.I WAS RESERVED AND UNEXPRESSIVE."
+                    }
+                },
+                "label": "Please rate your behavior in the situation you described.PLEASE RATE YOUR BEHAVIOR IN THE SITUATION YOU DESCRIBED.",
+                "options": {
+                    "extremelyChar": "Extremely CharacteristicEXTREMELY CHARACTERISTIC",
+                    "extremelyUnchar": "Extremely UncharacteristicEXTREMELY UNCHARACTERISTIC",
+                    "fairlyChar": "Fairly CharacteristicFAIRLY CHARACTERISTIC",
+                    "fairlyUnchar": "Fairly UncharacteristicFAIRLY UNCHARACTERISTIC",
+                    "neutral": "Neither Characteristic nor UncharacteristicNEITHER CHARACTERISTIC NOR UNCHARACTERISTIC",
+                    "quiteChar": "Quite CharacteristicQUITE CHARACTERISTIC",
+                    "quiteUnchar": "Quite UncharacteristicQUITE UNCHARACTERISTIC",
+                    "somewhatChar": "Somewhat CharacteristicSOMEWHAT CHARACTERISTIC",
+                    "somewhatUnchar": "Somewhat UncharacteristicSOMEWHAT UNCHARACTERISTIC"
+                }
+            },
+            "4": {
+                "label": "How do you see yourself: Are you generally a person who is fully prepared to take risks or do you try to avoid taking risks?HOW DO YOU SEE YOURSELF: ARE YOU GENERALLY A PERSON WHO IS FULLY PREPARED TO TAKE RISKS OR DO YOU TRY TO AVOID TAKING RISKS?",
+                "options": {
+                    "fullyPrepared": "Fully prepared to take risks.FULLY PREPARED TO TAKE RISKS.",
+                    "unwilling": "Unwilling to take risksUNWILLING TO TAKE RISKS"
+                }
+            },
+            "5": {
+                "items": {
+                    "1": {
+                        "label": "Is outgoing, sociableIS OUTGOING, SOCIABLE"
+                    },
+                    "10": {
+                        "label": "Is curious about many different thingsIS CURIOUS ABOUT MANY DIFFERENT THINGS"
+                    },
+                    "11": {
+                        "label": "Rarely feels excited or eagerRARELY FEELS EXCITED OR EAGER"
+                    },
+                    "12": {
+                        "label": "Tends to find fault with othersTENDS TO FIND FAULT WITH OTHERS"
+                    },
+                    "13": {
+                        "label": "Is dependable, steadyIS DEPENDABLE, STEADY"
+                    },
+                    "14": {
+                        "label": "Is moody, has up and down mood swingsIS MOODY, HAS UP AND DOWN MOOD SWINGS"
+                    },
+                    "15": {
+                        "label": "Is inventive, finds clever ways to do thingsIS INVENTIVE, FINDS CLEVER WAYS TO DO THINGS"
+                    },
+                    "16": {
+                        "label": "Tends to be quietTENDS TO BE QUIET"
+                    },
+                    "17": {
+                        "label": "Feels little sympathy for othersFEELS LITTLE SYMPATHY FOR OTHERS"
+                    },
+                    "18": {
+                        "label": "Is systematic, likes to keep things in orderIS SYSTEMATIC, LIKES TO KEEP THINGS IN ORDER"
+                    },
+                    "19": {
+                        "label": "Can be tenseCAN BE TENSE"
+                    },
+                    "2": {
+                        "label": "Is compassionate, has a soft heartIS COMPASSIONATE, HAS A SOFT HEART"
+                    },
+                    "20": {
+                        "label": "Is fascinated by art, music, or literatureIS FASCINATED BY ART, MUSIC, OR LITERATURE"
+                    },
+                    "21": {
+                        "label": "Is dominant, acts as a leaderIS DOMINANT, ACTS AS A LEADER"
+                    },
+                    "22": {
+                        "label": "Starts arguments with othersSTARTS ARGUMENTS WITH OTHERS"
+                    },
+                    "23": {
+                        "label": "Has difficulty getting started on tasksHAS DIFFICULTY GETTING STARTED ON TASKS"
+                    },
+                    "24": {
+                        "label": "Feels secure, comfortable with selfFEELS SECURE, COMFORTABLE WITH SELF"
+                    },
+                    "25": {
+                        "label": "Avoids intellectual, philosophical discussionsAVOIDS INTELLECTUAL, PHILOSOPHICAL DISCUSSIONS"
+                    },
+                    "26": {
+                        "label": "Is less active than other peopleIS LESS ACTIVE THAN OTHER PEOPLE"
+                    },
+                    "27": {
+                        "label": "Has a forgiving natureHAS A FORGIVING NATURE"
+                    },
+                    "28": {
+                        "label": "Can be somewhat carelessCAN BE SOMEWHAT CARELESS"
+                    },
+                    "29": {
+                        "label": "Is emotionally stable, not easily upsetIS EMOTIONALLY STABLE, NOT EASILY UPSET"
+                    },
+                    "3": {
+                        "label": "Tends to be disorganizedTENDS TO BE DISORGANIZED"
+                    },
+                    "30": {
+                        "label": "Has little creativityHAS LITTLE CREATIVITY"
+                    },
+                    "31": {
+                        "label": "Is sometimes shy, introvertedIS SOMETIMES SHY, INTROVERTED"
+                    },
+                    "32": {
+                        "label": "Is helpful and unselfish with othersIS HELPFUL AND UNSELFISH WITH OTHERS"
+                    },
+                    "33": {
+                        "label": "Keeps things neat and tidyKEEPS THINGS NEAT AND TIDY"
+                    },
+                    "34": {
+                        "label": "Worries a lotWORRIES A LOT"
+                    },
+                    "35": {
+                        "label": "Values art and beautyVALUES ART AND BEAUTY"
+                    },
+                    "36": {
+                        "label": "Finds it hard to influence peopleFINDS IT HARD TO INFLUENCE PEOPLE"
+                    },
+                    "37": {
+                        "label": "Is sometimes rude to othersIS SOMETIMES RUDE TO OTHERS"
+                    },
+                    "38": {
+                        "label": "Is efficient, gets things doneIS EFFICIENT, GETS THINGS DONE"
+                    },
+                    "39": {
+                        "label": "Often feels sadOFTEN FEELS SAD"
+                    },
+                    "4": {
+                        "label": "Is relaxed, handles stress wellIS RELAXED, HANDLES STRESS WELL"
+                    },
+                    "40": {
+                        "label": "Is complex, a deep thinkerIS COMPLEX, A DEEP THINKER"
+                    },
+                    "41": {
+                        "label": "Is full of energyIS FULL OF ENERGY"
+                    },
+                    "42": {
+                        "label": "Is suspicious of others\u2019 intentionsIS SUSPICIOUS OF OTHERS\u2019 INTENTIONS"
+                    },
+                    "43": {
+                        "label": "Is reliable, can always be counted onIS RELIABLE, CAN ALWAYS BE COUNTED ON"
+                    },
+                    "44": {
+                        "label": "Keeps their emotions under controlKEEPS THEIR EMOTIONS UNDER CONTROL"
+                    },
+                    "45": {
+                        "label": "Has difficulty imagining thingsHAS DIFFICULTY IMAGINING THINGS"
+                    },
+                    "46": {
+                        "label": "Is talkativeIS TALKATIVE"
+                    },
+                    "47": {
+                        "label": "Can be cold and uncaringCAN BE COLD AND UNCARING"
+                    },
+                    "48": {
+                        "label": "Leaves a mess, doesn\u2019t clean upLEAVES A MESS, DOESN\u2019T CLEAN UP"
+                    },
+                    "49": {
+                        "label": "Rarely feels anxious or afraidRARELY FEELS ANXIOUS OR AFRAID"
+                    },
+                    "5": {
+                        "label": "Has few artistic interestsHAS FEW ARTISTIC INTERESTS"
+                    },
+                    "50": {
+                        "label": "Thinks poetry and plays are boringTHINKS POETRY AND PLAYS ARE BORING"
+                    },
+                    "51": {
+                        "label": "Prefers to have others take chargePREFERS TO HAVE OTHERS TAKE CHARGE"
+                    },
+                    "52": {
+                        "label": "Is polite, courteous to othersIS POLITE, COURTEOUS TO OTHERS"
+                    },
+                    "53": {
+                        "label": "Is persistent, works until the task is finishedIS PERSISTENT, WORKS UNTIL THE TASK IS FINISHED"
+                    },
+                    "54": {
+                        "label": "Tends to feel depressedTENDS TO FEEL DEPRESSED"
+                    },
+                    "55": {
+                        "label": "Has little interest in abstract ideasHAS LITTLE INTEREST IN ABSTRACT IDEAS"
+                    },
+                    "56": {
+                        "label": "Shows a lot of enthusiasmSHOWS A LOT OF ENTHUSIASM"
+                    },
+                    "57": {
+                        "label": "Assumes the best about peopleASSUMES THE BEST ABOUT PEOPLE"
+                    },
+                    "58": {
+                        "label": "Sometimes behaves irresponsiblySOMETIMES BEHAVES IRRESPONSIBLY"
+                    },
+                    "59": {
+                        "label": "Is temperamental, gets emotional easilyIS TEMPERAMENTAL, GETS EMOTIONAL EASILY"
+                    },
+                    "6": {
+                        "label": "Has an assertive personalityHAS AN ASSERTIVE PERSONALITY"
+                    },
+                    "60": {
+                        "label": "Is original, comes up with new ideasIS ORIGINAL, COMES UP WITH NEW IDEAS"
+                    },
+                    "7": {
+                        "label": "Is respectful, treats others with respectIS RESPECTFUL, TREATS OTHERS WITH RESPECT"
+                    },
+                    "8": {
+                        "label": "Tends to be lazyTENDS TO BE LAZY"
+                    },
+                    "9": {
+                        "label": "Stays optimistic after experiencing a setbackSTAYS OPTIMISTIC AFTER EXPERIENCING A SETBACK"
+                    }
+                },
+                "label": "Please rate the extent to which you agree or disagree with the following statements:\n \nI am someone who...PLEASE RATE THE EXTENT TO WHICH YOU AGREE OR DISAGREE WITH THE FOLLOWING STATEMENTS:\n \nI AM SOMEONE WHO...",
+                "options": {
+                    "agree": "AgreeAGREE",
+                    "agreeStrongly": "Agree stronglyAGREE STRONGLY",
+                    "disagree": "DisagreeDISAGREE",
+                    "disagreeStrongly": "Disagree stronglyDISAGREE STRONGLY",
+                    "neutral": "Neutral; no opinionNEUTRAL; NO OPINION"
+                }
+            },
+            "6": {
+                "items": {
+                    "1": {
+                        "label": "In general, I consider myselfIN GENERAL, I CONSIDER MYSELF",
+                        "options": {
+                            "notHappy": "Not a very happy personNOT A VERY HAPPY PERSON",
+                            "veryHappy": "A very happy personA VERY HAPPY PERSON"
+                        }
+                    },
+                    "2": {
+                        "label": "Compared to most of the people around me, I consider myselfCOMPARED TO MOST OF THE PEOPLE AROUND ME, I CONSIDER MYSELF",
+                        "options": {
+                            "lessHappy": "Less happyLESS HAPPY",
+                            "moreHappy": "More happyMORE HAPPY"
+                        }
+                    },
+                    "3": {
+                        "label": "Some people are generally very happy. They enjoy life regardless of what is going on, getting the most out of everything. \n  To what extent does this characterization describe you?SOME PEOPLE ARE GENERALLY VERY HAPPY. THEY ENJOY LIFE REGARDLESS OF WHAT IS GOING ON, GETTING THE MOST OUT OF EVERYTHING. \n  TO WHAT EXTENT DOES THIS CHARACTERIZATION DESCRIBE YOU?",
+                        "options": {
+                            "aGreatDeal": "A great dealA GREAT DEAL",
+                            "notAtAll": "Not at allNOT AT ALL"
+                        }
+                    },
+                    "4": {
+                        "label": "Some people are generally not very happy. Although they are not depressed, they never seem as happy as they might be. \n  To what extent does this characterization describe you?SOME PEOPLE ARE GENERALLY NOT VERY HAPPY. ALTHOUGH THEY ARE NOT DEPRESSED, THEY NEVER SEEM AS HAPPY AS THEY MIGHT BE. \n  TO WHAT EXTENT DOES THIS CHARACTERIZATION DESCRIBE YOU?",
+                        "options": {
+                            "aGreatDeal": "A great dealA GREAT DEAL",
+                            "notAtAll": "Not at allNOT AT ALL"
+                        }
+                    }
+                },
+                "label": "For each of the following questions, please indicate the point on the 7-point scale that best describes you.FOR EACH OF THE FOLLOWING QUESTIONS, PLEASE INDICATE THE POINT ON THE 7-POINT SCALE THAT BEST DESCRIBES YOU."
+            },
+            "7": {
+                "items": {
+                    "1": {
+                        "label": "I believe that I and those around me are happyI BELIEVE THAT I AND THOSE AROUND ME ARE HAPPY"
+                    },
+                    "2": {
+                        "label": "I feel that I am being positively evaluated by others around meI FEEL THAT I AM BEING POSITIVELY EVALUATED BY OTHERS AROUND ME"
+                    },
+                    "3": {
+                        "label": "I make significant others happyI MAKE SIGNIFICANT OTHERS HAPPY"
+                    },
+                    "4": {
+                        "label": "Although it is quite average, I live a stable lifeALTHOUGH IT IS QUITE AVERAGE, I LIVE A STABLE LIFE"
+                    },
+                    "5": {
+                        "label": "I do not have any major concerns or anxietiesI DO NOT HAVE ANY MAJOR CONCERNS OR ANXIETIES"
+                    },
+                    "6": {
+                        "label": "I can do what I want without causing problems for other peopleI CAN DO WHAT I WANT WITHOUT CAUSING PROBLEMS FOR OTHER PEOPLE"
+                    },
+                    "7": {
+                        "label": "I believe that my life is just as happy as that of others around meI BELIEVE THAT MY LIFE IS JUST AS HAPPY AS THAT OF OTHERS AROUND ME"
+                    },
+                    "8": {
+                        "label": "I believe that I have achieved the same standard of living as those around meI BELIEVE THAT I HAVE ACHIEVED THE SAME STANDARD OF LIVING AS THOSE AROUND ME"
+                    },
+                    "9": {
+                        "label": "I generally believe that things are going as well for me as they are for others around meI GENERALLY BELIEVE THAT THINGS ARE GOING AS WELL FOR ME AS THEY ARE FOR OTHERS AROUND ME"
+                    }
+                },
+                "label": "Please rate the extent to which you agree or disagree with the following statements:PLEASE RATE THE EXTENT TO WHICH YOU AGREE OR DISAGREE WITH THE FOLLOWING STATEMENTS:",
+                "options": {
+                    "agree": "AgreeAGREE",
+                    "agreeStrongly": "Agree stronglyAGREE STRONGLY",
+                    "disagree": "DisagreeDISAGREE",
+                    "disagreeStrongly": "Disagree stronglyDISAGREE STRONGLY",
+                    "neutral": "Neutral; no opinionNEUTRAL; NO OPINION"
+                }
+            },
+            "8": {
+                "items": {
+                    "1": {
+                        "label": "Belief in a religion helps one understand the meaning of lifeBELIEF IN A RELIGION HELPS ONE UNDERSTAND THE MEANING OF LIFE"
+                    },
+                    "10": {
+                        "label": "Only weak people need religionONLY WEAK PEOPLE NEED RELIGION"
+                    },
+                    "11": {
+                        "label": "Religion makes people escape from realityRELIGION MAKES PEOPLE ESCAPE FROM REALITY"
+                    },
+                    "12": {
+                        "label": "Practicing a religion unites people with othersPRACTICING A RELIGION UNITES PEOPLE WITH OTHERS"
+                    },
+                    "13": {
+                        "label": "Religious people are more likely to maintain moral standardsRELIGIOUS PEOPLE ARE MORE LIKELY TO MAINTAIN MORAL STANDARDS"
+                    },
+                    "14": {
+                        "label": "Religious beliefs lead to unscientific thinkingRELIGIOUS BELIEFS LEAD TO UNSCIENTIFIC THINKING"
+                    },
+                    "15": {
+                        "label": "Ignorance leads people to believe in a supreme beingIGNORANCE LEADS PEOPLE TO BELIEVE IN A SUPREME BEING"
+                    },
+                    "16": {
+                        "label": "Evidence of a supreme being is everywhere for those who seek its signsEVIDENCE OF A SUPREME BEING IS EVERYWHERE FOR THOSE WHO SEEK ITS SIGNS"
+                    },
+                    "17": {
+                        "label": "Religion contradicts scienceRELIGION CONTRADICTS SCIENCE"
+                    },
+                    "2": {
+                        "label": "Religion helps people make good choices for their livesRELIGION HELPS PEOPLE MAKE GOOD CHOICES FOR THEIR LIVES"
+                    },
+                    "3": {
+                        "label": "Religious faith contributes to good mental healthRELIGIOUS FAITH CONTRIBUTES TO GOOD MENTAL HEALTH"
+                    },
+                    "4": {
+                        "label": "Religion slows down human progressRELIGION SLOWS DOWN HUMAN PROGRESS"
+                    },
+                    "5": {
+                        "label": "There is a supreme being controlling the universeTHERE IS A SUPREME BEING CONTROLLING THE UNIVERSE"
+                    },
+                    "6": {
+                        "label": "Religion makes people healthierRELIGION MAKES PEOPLE HEALTHIER"
+                    },
+                    "7": {
+                        "label": "Religion makes people happierRELIGION MAKES PEOPLE HAPPIER"
+                    },
+                    "8": {
+                        "label": "Belief in a religion makes people good citizensBELIEF IN A RELIGION MAKES PEOPLE GOOD CITIZENS"
+                    },
+                    "9": {
+                        "label": "Religious practice makes it harder for people to think independentlyRELIGIOUS PRACTICE MAKES IT HARDER FOR PEOPLE TO THINK INDEPENDENTLY"
+                    }
+                },
+                "label": "Please rate the extent to which you agree or disagree with the following statements:PLEASE RATE THE EXTENT TO WHICH YOU AGREE OR DISAGREE WITH THE FOLLOWING STATEMENTS:",
+                "options": {
+                    "believeLittle": "Believe a littleBELIEVE A LITTLE",
+                    "believeStrong": "Strongly believeSTRONGLY BELIEVE",
+                    "disbelieveLittle": "Disbelieve a littleDISBELIEVE A LITTLE",
+                    "disbelieveStrong": "Strongly disbelieveSTRONGLY DISBELIEVE",
+                    "neutral": "Neutral; no opinionNEUTRAL; NO OPINION",
+                    "preferNoAnswer": "I prefer not to answerI PREFER NOT TO ANSWER"
+                }
+            },
+            "9": {
+                "items": {
+                    "1": {
+                        "label": "You prefer to say what you are thinking, even if it is inappropriate for the situationYOU PREFER TO SAY WHAT YOU ARE THINKING, EVEN IF IT IS INAPPROPRIATE FOR THE SITUATION"
+                    },
+                    "10": {
+                        "label": "You value good relations with the people close to you more than your personal achievementsYOU VALUE GOOD RELATIONS WITH THE PEOPLE CLOSE TO YOU MORE THAN YOUR PERSONAL ACHIEVEMENTS"
+                    },
+                    "11": {
+                        "label": "You always put your family first, even if it means giving up your personal goalsYOU ALWAYS PUT YOUR FAMILY FIRST, EVEN IF IT MEANS GIVING UP YOUR PERSONAL GOALS"
+                    },
+                    "12": {
+                        "label": "You are more concerned with your friends\u2019 happiness than your own successYOU ARE MORE CONCERNED WITH YOUR FRIENDS\u2019 HAPPINESS THAN YOUR OWN SUCCESS"
+                    },
+                    "2": {
+                        "label": "You show your inner feelings even if it disturbs the harmony in your familyYOU SHOW YOUR INNER FEELINGS EVEN IF IT DISTURBS THE HARMONY IN YOUR FAMILY"
+                    },
+                    "3": {
+                        "label": "You are comfortable expressing disagreement with friendsYOU ARE COMFORTABLE EXPRESSING DISAGREEMENT WITH FRIENDS"
+                    },
+                    "4": {
+                        "label": "You try to adapt to people around you, even if it means hiding your inner feelingsYOU TRY TO ADAPT TO PEOPLE AROUND YOU, EVEN IF IT MEANS HIDING YOUR INNER FEELINGS"
+                    },
+                    "5": {
+                        "label": "You feel uncomfortable when you express disagreement with members of your familyYOU FEEL UNCOMFORTABLE WHEN YOU EXPRESS DISAGREEMENT WITH MEMBERS OF YOUR FAMILY"
+                    },
+                    "6": {
+                        "label": "You try to maintain harmony among the people around youYOU TRY TO MAINTAIN HARMONY AMONG THE PEOPLE AROUND YOU"
+                    },
+                    "7": {
+                        "label": "You value personal achievements more than good relations with the people close to youYOU VALUE PERSONAL ACHIEVEMENTS MORE THAN GOOD RELATIONS WITH THE PEOPLE CLOSE TO YOU"
+                    },
+                    "8": {
+                        "label": "Your own success is very important to you, even if it disrupts your friendshipsYOUR OWN SUCCESS IS VERY IMPORTANT TO YOU, EVEN IF IT DISRUPTS YOUR FRIENDSHIPS"
+                    },
+                    "9": {
+                        "label": "You follow your personal goals even if they are very different from the goals of your familyYOU FOLLOW YOUR PERSONAL GOALS EVEN IF THEY ARE VERY DIFFERENT FROM THE GOALS OF YOUR FAMILY"
+                    }
+                },
+                "label": "Please rate the extent to which the following statements describe you.PLEASE RATE THE EXTENT TO WHICH THE FOLLOWING STATEMENTS DESCRIBE YOU.",
+                "options": {
+                    "aLittle": "A littleA LITTLE",
+                    "exactly": "ExactlyEXACTLY",
+                    "moderately": "ModeratelyMODERATELY",
+                    "notAtAll": "Not at allNOT AT ALL",
+                    "veryWell": "Very wellVERY WELL"
+                }
+            }
+        }
+    },
+    "previouslogin": {
+        "line1": "Our records indicate that you have already completed this study.OUR RECORDS INDICATE THAT YOU HAVE ALREADY COMPLETED THIS STUDY.",
+        "line2": "If this is in error, please contact your local International Situations Project coordinator.IF THIS IS IN ERROR, PLEASE CONTACT YOUR LOCAL INTERNATIONAL SITUATIONS PROJECT COORDINATOR."
+    },
+    "qsort": {
+        "rsq": {
+            "item": {
+                "SomoneCountedon": "Someone present (other than you) is counted on to do something.SOMEONE PRESENT (OTHER THAN YOU) IS COUNTED ON TO DO SOMETHING.",
+                "abusedVictimized": "You are being abused or victimized.YOU ARE BEING ABUSED OR VICTIMIZED.",
+                "adviceYou": "Others want advice from you.OTHERS WANT ADVICE FROM YOU.",
+                "ambition": "Ambition can be expressed or demonstrated.AMBITION CAN BE EXPRESSED OR DEMONSTRATED.",
+                "anxietyInducing": "The situation is potentially anxiety-inducing.THE SITUATION IS POTENTIALLY ANXIETY-INDUCING.",
+                "art": "Art is an important part of the situation.ART IS AN IMPORTANT PART OF THE SITUATION.",
+                "askingYou": "Someone is asking you for something.SOMEONE IS ASKING YOU FOR SOMETHING.",
+                "assertivenessGoal": "Assertiveness is required to accomplish a goal.ASSERTIVENESS IS REQUIRED TO ACCOMPLISH A GOAL.",
+                "athleticsSports": "People are participating in athletics or sports.PEOPLE ARE PARTICIPATING IN ATHLETICS OR SPORTS.",
+                "blaming": "Someone is blaming you for something.SOMEONE IS BLAMING YOU FOR SOMETHING.",
+                "breakingRules": "Someone is breaking rules.SOMEONE IS BREAKING RULES.",
+                "clearRules": "Clear rules define appropriate behavior (whether or not the rules are being followed).CLEAR RULES DEFINE APPROPRIATE BEHAVIOR (WHETHER OR NOT THE RULES ARE BEING FOLLOWED).",
+                "closeRelationships": "The people who are present have close personal relationships with each other.THE PEOPLE WHO ARE PRESENT HAVE CLOSE PERSONAL RELATIONSHIPS WITH EACH OTHER.",
+                "comparingThemselves": "People are comparing themselves to each other.PEOPLE ARE COMPARING THEMSELVES TO EACH OTHER.",
+                "competing": "People are competing with each other.PEOPLE ARE COMPETING WITH EACH OTHER.",
+                "complex": "The situation is complex.THE SITUATION IS COMPLEX.",
+                "complimentingYou": "Someone is complimenting or praising you.SOMEONE IS COMPLIMENTING OR PRAISING YOU.",
+                "conformToOthers": "You are being pressured to conform to the actions of others.YOU ARE BEING PRESSURED TO CONFORM TO THE ACTIONS OF OTHERS.",
+                "convinceYou": "Someone is trying to convince you of something.SOMEONE IS TRYING TO CONVINCE YOU OF SOMETHING.",
+                "countingOnYou": "Someone is counting on you to do something.SOMEONE IS COUNTING ON YOU TO DO SOMETHING.",
+                "criticizing": "Someone is criticizing you.SOMEONE IS CRITICIZING YOU.",
+                "decision": "A decision needs to be made.A DECISION NEEDS TO BE MADE.",
+                "desiresGratified": "Desires could be gratified (for example, food, shopping, sexual opportunities).DESIRES COULD BE GRATIFIED (FOR EXAMPLE, FOOD, SHOPPING, SEXUAL OPPORTUNITIES).",
+                "differentRoles": "People who are present occupy different social roles or levels of status.PEOPLE WHO ARE PRESENT OCCUPY DIFFERENT SOCIAL ROLES OR LEVELS OF STATUS.",
+                "disagreeing": "People are disagreeing about something.PEOPLE ARE DISAGREEING ABOUT SOMETHING.",
+                "dominate": "Someone is attempting to dominate or boss you.SOMEONE IS ATTEMPTING TO DOMINATE OR BOSS YOU.",
+                "emotionalThreats": "Emotional threats are present.EMOTIONAL THREATS ARE PRESENT.",
+                "emotionsExpressed": "Emotions can be expressed.EMOTIONS CAN BE EXPRESSED.",
+                "entertainment": "Entertainment is present.ENTERTAINMENT IS PRESENT.",
+                "family": "Family is important in this situation.FAMILY IS IMPORTANT IN THIS SITUATION.",
+                "feelInadequate": "The situation could make you feel inadequate.THE SITUATION COULD MAKE YOU FEEL INADEQUATE.",
+                "femininity": "Femininity can be expressed.FEMININITY CAN BE EXPRESSED.",
+                "food": "Food is important in this situation.FOOD IS IMPORTANT IN THIS SITUATION.",
+                "frustrating": "The situation is frustrating (for example: a goal is blocked).THE SITUATION IS FRUSTRATING (FOR EXAMPLE: A GOAL IS BLOCKED).",
+                "goodImpression": "It is important for you to make a good impression.IT IS IMPORTANT FOR YOU TO MAKE A GOOD IMPRESSION.",
+                "happeningOnce": "Many things are happening at once.MANY THINGS ARE HAPPENING AT ONCE.",
+                "honor": "A matter of honor is at stake.A MATTER OF HONOR IS AT STAKE.",
+                "hostile": "The situation could make people feel hostile.THE SITUATION COULD MAKE PEOPLE FEEL HOSTILE.",
+                "humorous": "The situation is humorous or potentially humorous.THE SITUATION IS HUMOROUS OR POTENTIALLY HUMOROUS.",
+                "intellectuallyStimulating": "The situation could be intellectually stimulating.THE SITUATION COULD BE INTELLECTUALLY STIMULATING.",
+                "intelligence": "Intelligence is important (for example: an intellectual discussion, a complex problem that needs to be solved).INTELLIGENCE IS IMPORTANT (FOR EXAMPLE: AN INTELLECTUAL DISCUSSION, A COMPLEX PROBLEM THAT NEEDS TO BE SOLVED).",
+                "jobDone": "A job needs to be done.A JOB NEEDS TO BE DONE.",
+                "masculinity": "Masculinity can be expressed.MASCULINITY CAN BE EXPRESSED.",
+                "minorDetails": "Minor details are important.MINOR DETAILS ARE IMPORTANT.",
+                "money": "Money is important.MONEY IS IMPORTANT.",
+                "moralIssues": "Moral or ethical issues are relevant.MORAL OR ETHICAL ISSUES ARE RELEVANT.",
+                "music": "Music is an important part of this situation.MUSIC IS AN IMPORTANT PART OF THIS SITUATION.",
+                "needsHelp": "Someone needs help.SOMEONE NEEDS HELP.",
+                "negativeEmotions": "The situation could arouse negative emotions.THE SITUATION COULD AROUSE NEGATIVE EMOTIONS.",
+                "newRelationships": "New relationships could develop.NEW RELATIONSHIPS COULD DEVELOP.",
+                "noisy": "The situation is noisy (low placement means the situation is very quiet).THE SITUATION IS NOISY (LOW PLACEMENT MEANS THE SITUATION IS VERY QUIET).",
+                "notClear": "It is not clear what is going on; the situation is uncertain.IT IS NOT CLEAR WHAT IS GOING ON; THE SITUATION IS UNCERTAIN.",
+                "oppositeSex": "The presence of members of the opposite sex is an important part of this situation.THE PRESENCE OF MEMBERS OF THE OPPOSITE SEX IS AN IMPORTANT PART OF THIS SITUATION.",
+                "peopleGetAlong": "It is important for people to get along.IT IS IMPORTANT FOR PEOPLE TO GET ALONG.",
+                "physicalAttractiveness": "Your physical attractiveness is important.YOUR PHYSICAL ATTRACTIVENESS IS IMPORTANT.",
+                "physicalThreats": "Physical threats are present.PHYSICAL THREATS ARE PRESENT.",
+                "physicallyActive": "People are being physically active.PEOPLE ARE BEING PHYSICALLY ACTIVE.",
+                "physicallyUncomfortable": "The situation is physically uncomfortable (for example: too hot, too crowded, too cold, etc.). (Low placement implies the situation is physically very comfortable.)THE SITUATION IS PHYSICALLY UNCOMFORTABLE (FOR EXAMPLE: TOO HOT, TOO CROWDED, TOO COLD, ETC.). (LOW PLACEMENT IMPLIES THE SITUATION IS PHYSICALLY VERY COMFORTABLE.)",
+                "playful": "The situation is playful.THE SITUATION IS PLAYFUL.",
+                "politics": "Politics are relevant (for example: a political discussion).POLITICS ARE RELEVANT (FOR EXAMPLE: A POLITICAL DISCUSSION).",
+                "positiveEmotions": "The situation could arouse positive emotions.THE SITUATION COULD AROUSE POSITIVE EMOTIONS.",
+                "potentiallyEnjoy": "The situation is potentially enjoyable.THE SITUATION IS POTENTIALLY ENJOYABLE.",
+                "power": "Power is important.POWER IS IMPORTANT.",
+                "quickAction": "Quick action is necessary.QUICK ACTION IS NECESSARY.",
+                "rapidlyChanging": "The situation is rapidly changing.THE SITUATION IS RAPIDLY CHANGING.",
+                "reassurance": "Someone needs or desires reassurance.SOMEONE NEEDS OR DESIRES REASSURANCE.",
+                "reassuringPresent": "A reassuring person is present.A REASSURING PERSON IS PRESENT.",
+                "relevantHealth": "The situation is relevant to your health (for example: possibility of illness, a medical visit).THE SITUATION IS RELEVANT TO YOUR HEALTH (FOR EXAMPLE: POSSIBILITY OF ILLNESS, A MEDICAL VISIT).",
+                "religion": "Religion is relevant in this situation (for example: a religious service or discussion).RELIGION IS RELEVANT IN THIS SITUATION (FOR EXAMPLE: A RELIGIOUS SERVICE OR DISCUSSION).",
+                "romanticPartners": "Potential or actual romantic partners (for you) are present.POTENTIAL OR ACTUAL ROMANTIC PARTNERS (FOR YOU) ARE PRESENT.",
+                "ruminateDaydream": "It is possible to ruminate, daydream or fantasize.IT IS POSSIBLE TO RUMINATE, DAYDREAM OR FANTASIZE.",
+                "selfControl": "Self-control is necessary (for yourself or others).SELF-CONTROL IS NECESSARY (FOR YOURSELF OR OTHERS).",
+                "sensations": "Sensations are important (for example: touch, taste, smell, physical contact).SENSATIONS ARE IMPORTANT (FOR EXAMPLE: TOUCH, TASTE, SMELL, PHYSICAL CONTACT).",
+                "sexuality": "Sexuality is relevant.SEXUALITY IS RELEVANT.",
+                "shame": "Someone is feeling shame.SOMEONE IS FEELING SHAME.",
+                "simpleClearcut": "The situation is simple and clear-cut.THE SITUATION IS SIMPLE AND CLEAR-CUT.",
+                "smallAnnoyances": "The situation includes small annoyances.THE SITUATION INCLUDES SMALL ANNOYANCES.",
+                "socialInteraction": "Social interaction is possible.SOCIAL INTERACTION IS POSSIBLE.",
+                "successCooperation": "Success requires cooperation.SUCCESS REQUIRES COOPERATION.",
+                "takenCareOf": "Someone needs to be taken care of.SOMEONE NEEDS TO BE TAKEN CARE OF.",
+                "talkingExpected": "Talking is expected or demanded.TALKING IS EXPECTED OR DEMANDED.",
+                "talkingPermitted": "Talking is permitted.TALKING IS PERMITTED.",
+                "tenseUpset": "The situation could make people tense and upset.THE SITUATION COULD MAKE PEOPLE TENSE AND UPSET.",
+                "tryingImpress": "Someone is trying to impress you.SOMEONE IS TRYING TO IMPRESS YOU.",
+                "underThreat": "Someone is under threat.SOMEONE IS UNDER THREAT.",
+                "unhappySuffering": "Someone is unhappy or suffering.SOMEONE IS UNHAPPY OR SUFFERING.",
+                "unusualIdeas": "Unusual ideas or points of view are being discussed freely.UNUSUAL IDEAS OR POINTS OF VIEW ARE BEING DISCUSSED FREELY.",
+                "verbalFluency": "There are opportunities to display verbal fluency (for example: a debate, a monologue, an active conversation).THERE ARE OPPORTUNITIES TO DISPLAY VERBAL FLUENCY (FOR EXAMPLE: A DEBATE, A MONOLOGUE, AN ACTIVE CONVERSATION).",
+                "workingHard": "People are working hard.PEOPLE ARE WORKING HARD.",
+                "youFocus": "You are the focus of attention.YOU ARE THE FOCUS OF ATTENTION."
+            }
+        },
+        "sections": {
+            "1": {
+                "activity": "Activity:ACTIVITY:",
+                "categories": {
+                    "characteristic": "CharacteristicCHARACTERISTIC",
+                    "neutral": "NeutralNEUTRAL",
+                    "uncharacteristic": "UncharacteristicUNCHARACTERISTIC"
+                },
+                "instructions": "Now please describe the situation you experienced in more detail. 90 items will appear one at a time.  Place each item into one of three boxes.  Use the \u201cCharacteristic\u201d box on the right for items that accurately describe the situation; use the \u201cUncharacteristic\u201d box on the left for items that are undescriptive of the situation, and use the \u201cNeutral\u201d box for items that are irrelevant, unclear, or about which you are uncertain.  When you are finished, press \u201cContinue.\u201dNOW PLEASE DESCRIBE THE SITUATION YOU EXPERIENCED IN MORE DETAIL. 90 ITEMS WILL APPEAR ONE AT A TIME.  PLACE EACH ITEM INTO ONE OF THREE BOXES.  USE THE \u201cCHARACTERISTIC\u201d BOX ON THE RIGHT FOR ITEMS THAT ACCURATELY DESCRIBE THE SITUATION; USE THE \u201cUNCHARACTERISTIC\u201d BOX ON THE LEFT FOR ITEMS THAT ARE UNDESCRIPTIVE OF THE SITUATION, AND USE THE \u201cNEUTRAL\u201d BOX FOR ITEMS THAT ARE IRRELEVANT, UNCLEAR, OR ABOUT WHICH YOU ARE UNCERTAIN.  WHEN YOU ARE FINISHED, PRESS \u201cCONTINUE.\u201d",
+                "itemsLeft": "items leftITEMS LEFT",
+                "location": "Location:LOCATION:",
+                "othersPresent": "Others present:OTHERS PRESENT:"
+            },
+            "2": {
+                "categories": {
+                    "extremelyChar": "Extremely CharacteristicEXTREMELY CHARACTERISTIC",
+                    "extremelyUnchar": "Extremely UncharacteristicEXTREMELY UNCHARACTERISTIC",
+                    "fairlyChar": "Fairly CharacteristicFAIRLY CHARACTERISTIC",
+                    "fairlyUnchar": "Fairly UncharacteristicFAIRLY UNCHARACTERISTIC",
+                    "neutral": "Neither Characteristic nor UncharacteristicNEITHER CHARACTERISTIC NOR UNCHARACTERISTIC",
+                    "quiteChar": "Quite CharacteristicQUITE CHARACTERISTIC",
+                    "quiteUnchar": "Quite UncharacteristicQUITE UNCHARACTERISTIC",
+                    "somewhatChar": "Somewhat CharacteristicSOMEWHAT CHARACTERISTIC",
+                    "somewhatUnchar": "Somewhat UncharacteristicSOMEWHAT UNCHARACTERISTIC"
+                },
+                "instructions": "Now, please describe the situation more precisely. From the three boxes, please place the items into nine boxes. You can drag and drop items from one box to another, but if you leave too many items in any one box, the heading will turn red.  The heading will turn green when the right number of items is in the box.NOW, PLEASE DESCRIBE THE SITUATION MORE PRECISELY. FROM THE THREE BOXES, PLEASE PLACE THE ITEMS INTO NINE BOXES. YOU CAN DRAG AND DROP ITEMS FROM ONE BOX TO ANOTHER, BUT IF YOU LEAVE TOO MANY ITEMS IN ANY ONE BOX, THE HEADING WILL TURN RED.  THE HEADING WILL TURN GREEN WHEN THE RIGHT NUMBER OF ITEMS IS IN THE BOX."
+            }
+        }
+    },
+    "survey": {
+        "sections": {
+            "1": {
+                "instructions": "Welcome!  We are interested in situations people experience and what they do in them.  You will describe a situation you experienced recently and what you did in that situation. You will also be asked some questions about your attitudes and values.  Based on these responses, when you have completed the study, you will be given the option to receive information about your personality that we hope you will find interesting. The following will take less than an hour to complete. \n \nTo begin, please answer a few questions about yourself.WELCOME!  WE ARE INTERESTED IN SITUATIONS PEOPLE EXPERIENCE AND WHAT THEY DO IN THEM.  YOU WILL DESCRIBE A SITUATION YOU EXPERIENCED RECENTLY AND WHAT YOU DID IN THAT SITUATION. YOU WILL ALSO BE ASKED SOME QUESTIONS ABOUT YOUR ATTITUDES AND VALUES.  BASED ON THESE RESPONSES, WHEN YOU HAVE COMPLETED THE STUDY, YOU WILL BE GIVEN THE OPTION TO RECEIVE INFORMATION ABOUT YOUR PERSONALITY THAT WE HOPE YOU WILL FIND INTERESTING. THE FOLLOWING WILL TAKE LESS THAN AN HOUR TO COMPLETE. \n \nTO BEGIN, PLEASE ANSWER A FEW QUESTIONS ABOUT YOURSELF.",
+                "questions": {
+                    "1": {
+                        "label": "AgeAGE"
+                    },
+                    "10": {
+                        "label": "If so, which religon do you follow?IF SO, WHICH RELIGON DO YOU FOLLOW?"
+                    },
+                    "11": {
+                        "label": "Birth countryBIRTH COUNTRY"
+                    },
+                    "2": {
+                        "label": "GenderGENDER",
+                        "options": {
+                            "female": "FemaleFEMALE",
+                            "male": "MaleMALE",
+                            "na": "I would rather not stateI WOULD RATHER NOT STATE",
+                            "other": "OtherOTHER"
+                        }
+                    },
+                    "3": {
+                        "label": "What is your ethnicity?WHAT IS YOUR ETHNICITY?"
+                    },
+                    "4": {
+                        "label": "What was your first language?WHAT WAS YOUR FIRST LANGUAGE?"
+                    },
+                    "5": {
+                        "label": "On a scale from 1 to 10, where would you describe your family\u2019s economic position?ON A SCALE FROM 1 TO 10, WHERE WOULD YOU DESCRIBE YOUR FAMILY\u2019S ECONOMIC POSITION?",
+                        "options": {
+                            "average": "AverageAVERAGE",
+                            "least": "Least well offLEAST WELL OFF",
+                            "most": "Most well offMOST WELL OFF"
+                        }
+                    },
+                    "6": {
+                        "label": "Birth cityBIRTH CITY"
+                    },
+                    "7": {
+                        "label": "Hometown residenceHOMETOWN RESIDENCE",
+                        "options": {
+                            "remoteRural": "remote ruralREMOTE RURAL",
+                            "rural": "ruralRURAL",
+                            "suburban": "suburbanSUBURBAN",
+                            "urban": "urbanURBAN"
+                        }
+                    },
+                    "8": {
+                        "label": "On a scale from 1 to 10, how religious are you?ON A SCALE FROM 1 TO 10, HOW RELIGIOUS ARE YOU?",
+                        "options": {
+                            "highlyReligious": "Highly religiousHIGHLY RELIGIOUS",
+                            "notReligious": "Not at all religiousNOT AT ALL RELIGIOUS",
+                            "preferNoAnswer": "I prefer not to answerI PREFER NOT TO ANSWER"
+                        }
+                    },
+                    "9": {
+                        "label": "Do you follow a religion?DO YOU FOLLOW A RELIGION?",
+                        "options": {
+                            "noLabel": "NoNO",
+                            "preferNoAnswer": "I prefer not to answerI PREFER NOT TO ANSWER",
+                            "yesLabel": "YesYes"
+                        }
+                    }
+                }
+            },
+            "2": {
+                "instructions": {
+                    "firstSection": "Please describe an experience yesterday that you remember well. Specifically, please describe what you were doing, where you were, and who was present. Type your responses below.PLEASE DESCRIBE AN EXPERIENCE YESTERDAY THAT YOU REMEMBER WELL. SPECIFICALLY, PLEASE DESCRIBE WHAT YOU WERE DOING, WHERE YOU WERE, AND WHO WAS PRESENT. TYPE YOUR RESPONSES BELOW.",
+                    "secondSection": "Please type your responses in the boxes below.PLEASE TYPE YOUR RESPONSES IN THE BOXES BELOW."
+                },
+                "questions": {
+                    "11": {
+                        "characterCount": "0 out of 75 characters used0 OUT OF 75 CHARACTERS USED",
+                        "label": "What were you doing at this time?WHAT WERE YOU DOING AT THIS TIME?"
+                    },
+                    "12": {
+                        "characterCount": "0 out of 75 characters used0 OUT OF 75 CHARACTERS USED",
+                        "label": "Where were you?WHERE WERE YOU?"
+                    },
+                    "13": {
+                        "characterCount": "0 out of 75 characters used0 OUT OF 75 CHARACTERS USED",
+                        "label": "Who else was present? (If you were alone, please write \u201calone\u201d).WHO ELSE WAS PRESENT? (IF YOU WERE ALONE, PLEASE WRITE \u201cALONE\u201d)."
+                    },
+                    "14": {
+                        "label": "Approximately what time did this experience begin?APPROXIMATELY WHAT TIME DID THIS EXPERIENCE BEGIN?"
+                    }
+                }
+            }
+        }
+    },
+    "thankyou": {
+        "exitButton": "Exit to end studyEXIT TO END STUDY",
+        "instructions": "You may now exit the study, or proceed to receive some information about your personality based on the surveys you completed.YOU MAY NOW EXIT THE STUDY, OR PROCEED TO RECEIVE SOME INFORMATION ABOUT YOUR PERSONALITY BASED ON THE SURVEYS YOU COMPLETED.",
+        "personalityFeedbackButton": "Receive personality feedbackRECEIVE PERSONALITY FEEDBACK",
+        "title": "Thank you!THANK YOU!"
+    }
+};
+
+
+export default translations;


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-290

## Purpose
Add "test" locale that doubles each translation string to facilitate testing how long translations can affect the UI.

## Testing notes
Select the "Test" locale (the last button on the flag picker modal) and see that the translation strings change (e.g. "Continue --> ContinueCONTINUE")