### PR TITLE
Fix repeatedly clicking the back-button [LEI-304]

### DIFF
--- a/app/routes/participate/survey/index.js
+++ b/app/routes/participate/survey/index.js
@@ -10,15 +10,19 @@ export default Ember.Route.extend({
   actions: {
     willTransition(transition) {
       this._super(transition);
+      var oldURL = this.router.generate(this.routeName);
+      var newURL = this.router.location.getURL();
+      if (oldURL !== newURL) {
+        this.router.location.setURL(oldURL);
+      }
+
       if (transition.targetName === 'participate.survey.results' || transition.targetName === 'exit') {
         return true;
       }
 
       var frameIndex = this.controllerFor('participate.survey.index').get('frameIndex');
       var framePage = this.controllerFor('participate.survey.index').get('framePage');
-
       if (frameIndex !== 0) {
-        this.replaceWith('participate.survey.index');
         // Disable back button in qsort page 2, rating-form page 1, and thank-you page
         if (!(frameIndex === 2 && framePage === 1) && frameIndex !== 3 && frameIndex !== 4) {
           this.controllerFor('participate.survey.index').set('frameIndex', frameIndex - 1);
@@ -28,6 +32,7 @@ export default Ember.Route.extend({
           this.controllerFor('participate.survey.index').set('framePage', framePage - 1);
         }
       }
+      transition.abort();
     }
   }
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-304

## Purpose
When a user clicks the back button while on the `/survey` route, and then clicks the back button again before the url can change from `/` back to `/survey`, the page attempts to transition back from the `/` route.

## Summary of changes
When a user clicks the back button while on the `participate/survey/index route`, in the `willTransition` hook, set the router url to the old url and abort the transition instead of using `this.replaceWith`.

## Testing notes
On the first card sort form (frameIndex=2, surveyPage=0), double-click the browser's back button. The page should very quickly go back to the free-response form (frameIndex=1), and then to the overview form (frameIndex=0). The url should remain '/survey', but may "flash" as it gets updated.