### PR TITLE
Fix infinite redirect between consent page and survey index

### DIFF
--- a/app/routes/participate/survey.js
+++ b/app/routes/participate/survey.js
@@ -49,8 +49,8 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
       }).catch(reject);
     });
   },
-  beforeModel(params) {
-    this._super(params);
+  beforeModel(transition) {
+    this._super(transition);
 
     var locale;
     try {
@@ -58,8 +58,9 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
     } catch (e) {}
     if (!locale) {
       this.transitionTo('participate.login');
+    } else {
+      this.transitionTo('participate.survey.consent');
     }
-    this.transitionTo('participate.survey.consent');
   },
   activate () {
     let session = this.get('_session');

--- a/app/routes/participate/survey/consent.js
+++ b/app/routes/participate/survey/consent.js
@@ -13,7 +13,7 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         // If participant has previously visited the survey (which requires granting consent),
         // go directly to survey and skip consent page
         if (ENV.featureFlags.continueSession && session.get('hasGrantedConsent')) {
-            this.transitionTo('participate.survey');
+            this.transitionTo('participate.survey.index');
         }
         return session;
     }


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-303

## Purpose
Fix infinite redirect between consent page and survey index

## Summary of changes
Bugfix

## Testing notes
Occurs when using reused account with `featureFlags.continueSessions` set to true.

To test this:
1. If you are using a pre-existing session, then you may need to set ` showStudyCompletedPage: false` in config/environment.js. All other feature flags should be turned on (set to `true`)
2. Log in and go past the consent page to the first page of the survey
3. Change something in the code, to trigger livereload.

Before this fix, `participate.survey` and `participate.survey.consent` would endlessly redirect by design. This is because beforeModel was firing two transitions in sequence.

After the fix (moving code into else block), the page will refresh and take the user back to login screen.



[#LEI-303]