### PR TITLE
Feature: Fix login error handling

### DIFF
--- a/app/controllers/participate/login.js
+++ b/app/controllers/participate/login.js
@@ -24,7 +24,7 @@ export default Ember.Controller.extend({
           this.transitionToRoute('participate.survey.consent');
         })
         .catch((e) => {
-          if (e.status === 404) {
+          if (e.status === 404 || e.status === 401) {
             this.send('toggleInvalidAuth');
             this.set('authenticating', false);
           } else if (e.name === 'TransitionAborted') {

--- a/app/controllers/participate/login.js
+++ b/app/controllers/participate/login.js
@@ -16,7 +16,7 @@ export default Ember.Controller.extend({
   actions: {
     authenticate(attrs) {
       if (!this.get('locale')) {
-        this.send('toggleInvalidLocale');
+        this.toggleProperty('invalidLocale');
         this.set('authenticating', false);
         this.get('raven').captureMessage('Locale not selected');
       } else {
@@ -31,21 +31,15 @@ export default Ember.Controller.extend({
           .catch((e) => {
             this.set('authenticating', false);
             if (e.status === 404 || e.status === 401) {
-              this.send('toggleInvalidAuth');
+              this.toggleProperty('invalidAuth');
             } else {
-              this.send('toggleLoginError');
+              this.toggleProperty('loginError');
             }
           });
       }
     },
-    toggleInvalidAuth() {
-      this.toggleProperty('invalidAuth');
-    },
-    toggleInvalidLocale() {
-      this.toggleProperty('invalidLocale');
-    },
-    toggleLoginError() {
-      this.toggleProperty('loginError');
+    toggleAction(property) {
+      this.toggleProperty(property);
     },
     showLanguageSelector() {
       this.set('showLanguageSelector', true);

--- a/app/controllers/participate/login.js
+++ b/app/controllers/participate/login.js
@@ -29,9 +29,11 @@ export default Ember.Controller.extend({
             this.transitionToRoute('participate.survey.consent');
           })
           .catch((e) => {
+            this.set('authenticating', false);
             if (e.status === 404 || e.status === 401) {
               this.send('toggleInvalidAuth');
-              this.set('authenticating', false);
+            } else {
+              this.send('toggleLoginError');
             }
           });
       }
@@ -41,6 +43,9 @@ export default Ember.Controller.extend({
     },
     toggleInvalidLocale() {
       this.toggleProperty('invalidLocale');
+    },
+    toggleLoginError() {
+      this.toggleProperty('loginError');
     },
     showLanguageSelector() {
       this.set('showLanguageSelector', true);

--- a/app/routes/participate/survey.js
+++ b/app/routes/participate/survey.js
@@ -54,13 +54,12 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
 
     var locale;
     try {
-        locale = this.controllerFor('participate').get('locale');
-    } catch (e) {
-    }
+      locale = this.controllerFor('participate').get('locale');
+    } catch (e) {}
     if (!locale) {
-        this.transitionTo('participate.login');
+      this.transitionTo('participate.login');
     } else {
-        this.transitionTo('participate.survey.consent');
+      this.transitionTo('participate.survey.consent');
     }
   },
   activate () {

--- a/app/routes/participate/survey.js
+++ b/app/routes/participate/survey.js
@@ -54,12 +54,13 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
 
     var locale;
     try {
-      locale = this.controllerFor('participate').get('locale');
-    } catch (e) {}
+        locale = this.controllerFor('participate').get('locale');
+    } catch (e) {
+    }
     if (!locale) {
-      this.transitionTo('participate.login');
+        this.transitionTo('participate.login');
     } else {
-      this.transitionTo('participate.survey.consent');
+        this.transitionTo('participate.survey.consent');
     }
   },
   activate () {

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -7,6 +7,10 @@
         {{/if}}
         <button id="select-language" class="btn btn-default" {{action 'showLanguageSelector'}}>{{t 'login.changeButton'}}</button>
       </h3>
+    {{else}}
+        {{#unless showLanguageSelector}}
+            <button id="select-language" class="btn btn-default" {{action 'showLanguageSelector'}}>{{t 'login.changeButton'}}</button>
+        {{/unless}}
     {{/if}}
 
     {{#if invalidAuth}}

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -14,19 +14,19 @@
     {{/if}}
 
     {{#if invalidAuth}}
-      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleInvalidAuth')}}
+      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleAction' 'invalidAuth')}}
         {{#bs-modal-body}}Invalid Study ID or Participant ID.{{/bs-modal-body}}
       {{/bs-modal}}
     {{/if}}
 
     {{#if invalidLocale}}
-      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleInvalidLocale')}}
+      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleAction' 'invalidLocale')}}
         {{#bs-modal-body}}Please select a language before logging in.{{/bs-modal-body}}
       {{/bs-modal}}
     {{/if}}
 
     {{#if loginError}}
-      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleLoginError')}}
+      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleAction' 'loginError')}}
         {{#bs-modal-body}}Please try again later.{{/bs-modal-body}}
       {{/bs-modal}}
     {{/if}}

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -25,6 +25,12 @@
       {{/bs-modal}}
     {{/if}}
 
+    {{#if loginError}}
+      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleLoginError')}}
+        {{#bs-modal-body}}Please try again later.{{/bs-modal-body}}
+      {{/bs-modal}}
+    {{/if}}
+
     <div class="row">
       <div class="col-md-12">
         <h1>International Situations Project</h1>

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -14,19 +14,19 @@
     {{/if}}
 
     {{#if invalidAuth}}
-      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleAction' 'invalidAuth')}}
+      {{#bs-modal title="An error occured when logging in" closedAction=(action 'toggleAction' 'invalidAuth')}}
         {{#bs-modal-body}}Invalid Study ID or Participant ID.{{/bs-modal-body}}
       {{/bs-modal}}
     {{/if}}
 
     {{#if invalidLocale}}
-      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleAction' 'invalidLocale')}}
+      {{#bs-modal title="An error occured when logging in" closedAction=(action 'toggleAction' 'invalidLocale')}}
         {{#bs-modal-body}}Please select a language before logging in.{{/bs-modal-body}}
       {{/bs-modal}}
     {{/if}}
 
     {{#if loginError}}
-      {{#bs-modal title="An error occured when logging in." closedAction=(action 'toggleAction' 'loginError')}}
+      {{#bs-modal title="An error occured when logging in" closedAction=(action 'toggleAction' 'loginError')}}
         {{#bs-modal-body}}Please try again later.{{/bs-modal-body}}
       {{/bs-modal}}
     {{/if}}


### PR DESCRIPTION
Refs: https://trello.com/c/IWZpRHWC/3-invalid-study-id-locks-up-login-page

## Purpose
- If a user logs in with an invalid study ID and a valid participant ID or logs in without selecting a locale, the spinner next to the login button keeps on spinning instead of showing an error message to the user. 

## Summary of changes
- Handle 401 error when a user logs in with an invalid studyID so that it does not cause login to fail.
- If a user has not selected a locale, show an error message to the user when they click the button to login and do not authenticate 

## Testing notes
For invalid study ID and a valid participant ID: 
1. Log in with an invalid study ID and a valid participant ID
2. An error modal should appear that says "Invalid Study ID or Participant ID." When you dismiss the modal, you should be able to try logging in again.

For invalid locale: 
1. Change `backdropClose` to `true` in the flag picker modal in `login.hbs`
2. On the login page, instead of choosing a locale click outside of the modal to dismiss it
3. Enter valid study ID and participant ID, and click continue
4. Notice invalid locale error 