### PR TITLE
[rfr] Remove custom text from early exit modal

### DIFF
--- a/app/components/exp-player.js
+++ b/app/components/exp-player.js
@@ -1,0 +1,6 @@
+import ExpPlayer from 'exp-player/components/exp-player';
+
+export default ExpPlayer.extend({
+    // Show an early exit modal (return non-empty string), but only with browser default message- don't require translation of custom text.
+    messageEarlyExitModal: ' '
+});


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-311

## Purpose
Make sure that an early exit modal shows, but without requiring translation of user-facing text

## Summary of changes
Return a non-empty string with a single whitespace character.

## Testing notes
The modal should appear whenever you resume a study in progress, and attempt to exit with unsaved changes- eg by navigating away to another website before saving.

The modal behavior can be affected by browser version, eg before this year, Chrome showed the custom text (alongside some browser default text).

See these instructions for how to download an older browser:
https://www.flowdock.com/app/cos/es6/threads/7B6u_KeTKwOfxuqTY2PtkXgVcAT

(note that if you run a very old browser, it may sometimes cause loss of browser history or other personalized settings due to incompatibilities between profile formats over time)