### PR TITLE
Add missing ISP session model fields

### DIFF
--- a/app/models/session.js
+++ b/app/models/session.js
@@ -4,5 +4,7 @@ import Session from 'exp-models/models/session';
 export default Session.extend({
     hasGrantedConsent: DS.attr('boolean'), // Whether user agreed to participate in the study
     frameIndex: DS.attr({defaultValue: 0}), // Index of the last visited exp-frame component
-    surveyPage: DS.attr({defaultValue: 0}) // The last visited page within an exp-frame component
+    surveyPage: DS.attr({defaultValue: 0}), // The last visited page within an exp-frame component
+    studyId: DS.attr('string'), // The siteID for the location where the study was taken,
+    locale: DS.attr('string')
 });


### PR DESCRIPTION
## Purpose
In the model hook of `routes/participate/survey.js`, the locale and sessionId are set on the session, but these fields are not a part of the model definition and were not getting saved.

## Summary of changes
Add `locale` and `studyId` to the ISP session model

## Testing Notes
1. Log into ISP with a new test account
2. Send a request to JamDB to check that the `locale` and `studyId` are in that session's data