### PR TITLE
Verify that translations are complete and accurate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ testem.log
 .env
 .env-local
 env
+
+# Misc
+/scripts/*.json
+/scripts/*.csv


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-321

## Purpose
When we receive a translation from a partner, we should perform validation to make sure it is complete and up-to-date. (eg, not missing any newly added keys)

Things to test:
1. Make sure that the translation has all the keys described in a reference translation, no more or less
2. Make sure that all the translation strings provided have a non-empty value.

Validation is currently informational-only; it does not prevent an output file from being generated.

## Summary of changes
Adds validation described above. Also adds new flags for `--out` filename, `--test`ing mode (to prepare this script to be used on real production translations), and `--validate`, which currently user must explicitly request to be run.

## Testing notes
To set up:  export a translation file from Google Drive as CSV and save it in the same folder as this script. Then, extract the `en-us/translations.js` content to a new file called `en.json` and save it in the same folder as the script. (just the JSON part, so python can parse it) This latter file will be the "reference translation" against which all others are checked for completeness.

Run the script as:
`python format_translations --filename en-us.csv --validate`

If your sample file has only english text, add the `--test` flag, which writes strings from the english column instead of the final translation column. This can be useful for testing the script before any translations are done.

1. Verify that given a CSV, it writes a translation file
2. Verify that a warning is issued if a key is present but not filled out
3. Verify that a warning is issued if a key is present in the reference translation, but not in the file currently being processed.
  - And vice versa
  - For various levels of nesting


Not tested:
- Unicode support