### PR TITLE
Add German translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ env
 # Misc
 /scripts/*.json
 /scripts/*.csv
+
+/scripts/consent_forms/*csv
+!/scripts/consent_forms/test.csv

--- a/app/components/isp-consent-form/consentText.js
+++ b/app/components/isp-consent-form/consentText.js
@@ -8,13 +8,79 @@
 /**
  * Text related to consent form
  * @class isp-consent-form/consentText
-  */
+ */
 
 /**
  *
  * @property
  */
 const consentText = {
+    "BASE.CH": {
+        "buttonLabel": "Bitte akzeptieren Sie die Teilnahmebedingungen, um fortzufahren.",
+        "consentLabel": "Ich habe die obigen Aussagen gelesen und verstanden. Ich stimme einer Teilnahme an der Studie zu.",
+        "paragraphs": [
+            "Willkommen zu unserer Studie. Ihre Teilnahme wird innerhalb einer Sitzung ablaufen und weniger als eine Stunde dauern. Sie werden gebeten, eine Situation zu beschreiben, die Sie k\u00fcrzlich erlebt haben, sowie Ihr Verhalten in dieser Situation. Sie werden auch einige Fragen zu Ihren Werten und Einstellung erhalten. Wenn Sie dies m\u00f6chten, erhalten Sie am Ende der Studie personalisierte Information zu Ihrer Pers\u00f6nlichkeit.",
+            "Alle Ihre Angaben werden vertraulich behandelt und lassen sich nur anhand einer Nummer (nicht anhand Ihres Namens) zuordnen. Diese anonymen Daten werden f\u00fcr Forschungszwecke in einer Online Datenbank archiviert, welche vom Zentrum f\u00fcr offene Wissenschaften (www.cos.io) verwaltet wird. Damit Sie Ihre Befragung abschliessen k\u00f6nnen, muss jede Frage beantwortet werden. Sie k\u00f6nnen Ihre Teilnahme an der Studie aber zu jedem Zeitpunkt abbrechen, ohne negative Konsequenzen. Der m\u00f6gliche Nutzen dieser Forschung ist es, Menschen und ihr Leben \u00fcber Kulturen hinweg besser zu verstehen. Es gibt keine bekannten Risiken.",
+            "Wenn Sie Fragen zu dieser Studie oder zu Ihren Rechten als TeilnehmerIn haben, k\u00f6nnen Sie gerne die koordinierende Person kontaktieren (Janina B\u00fchler, janina.buehler@unibas.ch, Universit\u00e4t Basel), welche f\u00fcr die Datensammlung an Ihrem Ort zust\u00e4ndig ist. Auch k\u00f6nnen Sie das B\u00fcro der Forschungsintegrit\u00e4t der University of California, Riverside, per Email unter IRB@ucr.edu erreichen. Wir bedanken uns sehr f\u00fcr Ihre Mithilfe."
+        ],
+        "title": "Einverst\u00e4ndniserkl\u00e4rung zur Teilnahme an der Studie",
+        "versionHistory": "(Einverst\u00e4ndniserkl\u00e4rung: 14 October 2016)"
+    },
+    "BERL.DE": {
+        "buttonLabel": "Bitte akzeptieren Sie die Teilnahmebedingungen, um fortzufahren.",
+        "consentLabel": "Ich habe die obigen Aussagen gelesen und verstanden. Ich stimme einer Teilnahme an der Studie zu.",
+        "paragraphs": [
+            "Willkommen zu unserer Studie. Ihre Teilnahme wird innerhalb einer Sitzung ablaufen und weniger als eine Stunde dauern. Sie werden gebeten, eine Situation zu beschreiben, die Sie k\u00fcrzlich erlebt haben, sowie Ihr Verhalten in dieser Situation. Sie werden auch einige Fragen zu Ihren Werten und Einstellung erhalten. Wenn Sie dies m\u00f6chten, erhalten Sie am Ende der Studie personalisierte Information zu Ihrer Pers\u00f6nlichkeit.",
+            "Alle Ihre Angaben werden vertraulich behandelt und lassen sich nur anhand einer Nummer (nicht anhand Ihres Namens) zuordnen. Diese anonymen Daten werden f\u00fcr Forschungszwecke in einer Online Datenbank archiviert, welche vom Zentrum f\u00fcr offene Wissenschaften (www.cos.io) verwaltet wird. Damit Sie Ihre Befragung abschliessen k\u00f6nnen, muss jede Frage beantwortet werden. Sie k\u00f6nnen Ihre Teilnahme an der Studie aber zu jedem Zeitpunkt abbrechen, ohne negative Konsequenzen. Der m\u00f6gliche Nutzen dieser Forschung ist es, Menschen und ihr Leben \u00fcber Kulturen hinweg besser zu verstehen. Es gibt keine bekannten Risiken.",
+            "Wenn Sie Fragen zu dieser Studie oder zu Ihren Rechten als TeilnehmerIn haben, k\u00f6nnen Sie gerne die koordinierende Person kontaktieren (Matthias Ziegler, zieglema@hu-berlin.de, Humboldt Universit\u00e4t zu Berlin), welche f\u00fcr die Datensammlung an Ihrem Ort zust\u00e4ndig ist. Auch k\u00f6nnen Sie das B\u00fcro der Forschungsintegrit\u00e4t der University of California, Riverside, per Email unter IRB@ucr.edu erreichen. Wir bedanken uns sehr f\u00fcr Ihre Mithilfe."
+        ],
+        "title": "Einverst\u00e4ndniserkl\u00e4rung zur Teilnahme an der Studie",
+        "versionHistory": "(Einverst\u00e4ndniserkl\u00e4rung: 14 October 2016)"
+    },
+    "GOTT.DE": {
+        "buttonLabel": "Bitte akzeptieren Sie die Teilnahmebedingungen, um fortzufahren.",
+        "consentLabel": "Ich habe die obigen Aussagen gelesen und verstanden. Ich stimme einer Teilnahme an der Studie zu.",
+        "paragraphs": [
+            "Willkommen zu unserer Studie. Ihre Teilnahme wird innerhalb einer Sitzung ablaufen und weniger als eine Stunde dauern. Sie werden gebeten, eine Situation zu beschreiben, die Sie k\u00fcrzlich erlebt haben, sowie Ihr Verhalten in dieser Situation. Sie werden auch einige Fragen zu Ihren Werten und Einstellung erhalten. Wenn Sie dies m\u00f6chten, erhalten Sie am Ende der Studie personalisierte Information zu Ihrer Pers\u00f6nlichkeit.",
+            "Alle Ihre Angaben werden vertraulich behandelt und lassen sich nur anhand einer Nummer (nicht anhand Ihres Namens) zuordnen. Diese anonymen Daten werden f\u00fcr Forschungszwecke in einer Online Datenbank archiviert, welche vom Zentrum f\u00fcr offene Wissenschaften (www.cos.io) verwaltet wird. Damit Sie Ihre Befragung abschliessen k\u00f6nnen, muss jede Frage beantwortet werden. Sie k\u00f6nnen Ihre Teilnahme an der Studie aber zu jedem Zeitpunkt abbrechen, ohne negative Konsequenzen. Der m\u00f6gliche Nutzen dieser Forschung ist es, Menschen und ihr Leben \u00fcber Kulturen hinweg besser zu verstehen. Es gibt keine bekannten Risiken.",
+            "Wenn Sie Fragen zu dieser Studie oder zu Ihren Rechten als TeilnehmerIn haben, k\u00f6nnen Sie gerne die koordinierende Person kontaktieren (Lars Penke, lars.penke@gmail.com, Georg August University G\u00f6ttingen), welche f\u00fcr die Datensammlung an Ihrem Ort zust\u00e4ndig ist. Auch k\u00f6nnen Sie das B\u00fcro der Forschungsintegrit\u00e4t der University of California, Riverside, per Email unter IRB@ucr.edu erreichen. Wir bedanken uns sehr f\u00fcr Ihre Mithilfe."
+        ],
+        "title": "Einverst\u00e4ndniserkl\u00e4rung zur Teilnahme an der Studie",
+        "versionHistory": "(Einverst\u00e4ndniserkl\u00e4rung: 14 October 2016)"
+    },
+    "GRAZ.AU": {
+        "buttonLabel": "Bitte akzeptieren Sie die Teilnahmebedingungen, um fortzufahren.",
+        "consentLabel": "Ich habe die obigen Aussagen gelesen und verstanden. Ich stimme einer Teilnahme an der Studie zu.",
+        "paragraphs": [
+            "Willkommen zu unserer Studie. Ihre Teilnahme wird innerhalb einer Sitzung ablaufen und weniger als eine Stunde dauern. Sie werden gebeten, eine Situation zu beschreiben, die Sie k\u00fcrzlich erlebt haben, sowie Ihr Verhalten in dieser Situation. Sie werden auch einige Fragen zu Ihren Werten und Einstellung erhalten. Wenn Sie dies m\u00f6chten, erhalten Sie am Ende der Studie personalisierte Information zu Ihrer Pers\u00f6nlichkeit.",
+            "Alle Ihre Angaben werden vertraulich behandelt und lassen sich nur anhand einer Nummer (nicht anhand Ihres Namens) zuordnen. Diese anonymen Daten werden f\u00fcr Forschungszwecke in einer Online Datenbank archiviert, welche vom Zentrum f\u00fcr offene Wissenschaften (www.cos.io) verwaltet wird. Damit Sie Ihre Befragung abschliessen k\u00f6nnen, muss jede Frage beantwortet werden. Sie k\u00f6nnen Ihre Teilnahme an der Studie aber zu jedem Zeitpunkt abbrechen, ohne negative Konsequenzen. Der m\u00f6gliche Nutzen dieser Forschung ist es, Menschen und ihr Leben \u00fcber Kulturen hinweg besser zu verstehen. Es gibt keine bekannten Risiken.",
+            "Wenn Sie Fragen zu dieser Studie oder zu Ihren Rechten als TeilnehmerIn haben, k\u00f6nnen Sie gerne die koordinierende Person kontaktieren (Aljoscha Neubauer, aljoscha.neubauer@uni-graz.at, Universit\u00e4t Graz), welche f\u00fcr die Datensammlung an Ihrem Ort zust\u00e4ndig ist. Auch k\u00f6nnen Sie das B\u00fcro der Forschungsintegrit\u00e4t der University of California, Riverside, per Email unter IRB@ucr.edu erreichen. Wir bedanken uns sehr f\u00fcr Ihre Mithilfe."
+        ],
+        "title": "Einverst\u00e4ndniserkl\u00e4rung zur Teilnahme an der Studie",
+        "versionHistory": "(Einverst\u00e4ndniserkl\u00e4rung: 14 October 2016)"
+    },
+    "INNS.AU": {
+        "buttonLabel": "Bitte akzeptieren Sie die Teilnahmebedingungen, um fortzufahren.",
+        "consentLabel": "Ich habe die obigen Aussagen gelesen und verstanden. Ich stimme einer Teilnahme an der Studie zu.",
+        "paragraphs": [
+            "Willkommen zu unserer Studie. Ihre Teilnahme wird innerhalb einer Sitzung ablaufen und weniger als eine Stunde dauern. Sie werden gebeten, eine Situation zu beschreiben, die Sie k\u00fcrzlich erlebt haben, sowie Ihr Verhalten in dieser Situation. Sie werden auch einige Fragen zu Ihren Werten und Einstellung erhalten. Wenn Sie dies m\u00f6chten, erhalten Sie am Ende der Studie personalisierte Information zu Ihrer Pers\u00f6nlichkeit.",
+            "Alle Ihre Angaben werden vertraulich behandelt und lassen sich nur anhand einer Nummer (nicht anhand Ihres Namens) zuordnen. Diese anonymen Daten werden f\u00fcr Forschungszwecke in einer Online Datenbank archiviert, welche vom Zentrum f\u00fcr offene Wissenschaften (www.cos.io) verwaltet wird. Damit Sie Ihre Befragung abschliessen k\u00f6nnen, muss jede Frage beantwortet werden. Sie k\u00f6nnen Ihre Teilnahme an der Studie aber zu jedem Zeitpunkt abbrechen, ohne negative Konsequenzen. Der m\u00f6gliche Nutzen dieser Forschung ist es, Menschen und ihr Leben \u00fcber Kulturen hinweg besser zu verstehen. Es gibt keine bekannten Risiken.",
+            "Wenn Sie Fragen zu dieser Studie oder zu Ihren Rechten als TeilnehmerIn haben, k\u00f6nnen Sie gerne die koordinierende Person kontaktieren (Marco Furtner, marco.furtner@uibk.ac.at, Universit\u00e4t Innsbruck), welche f\u00fcr die Datensammlung an Ihrem Ort zust\u00e4ndig ist. Auch k\u00f6nnen Sie das B\u00fcro der Forschungsintegrit\u00e4t der University of California, Riverside, per Email unter IRB@ucr.edu erreichen. Wir bedanken uns sehr f\u00fcr Ihre Mithilfe."
+        ],
+        "title": "Einverst\u00e4ndniserkl\u00e4rung zur Teilnahme an der Studie",
+        "versionHistory": "(Einverst\u00e4ndniserkl\u00e4rung: 14 October 2016)"
+    },
+    "ZURI.CH": {
+        "buttonLabel": "Bitte akzeptieren Sie die Teilnahmebedingungen, um fortzufahren.",
+        "consentLabel": "Ich habe die obigen Aussagen gelesen und verstanden. Ich stimme einer Teilnahme an der Studie zu.",
+        "paragraphs": [
+            "Willkommen zu unserer Studie. Ihre Teilnahme wird innerhalb einer Sitzung ablaufen und weniger als eine Stunde dauern. Sie werden gebeten, eine Situation zu beschreiben, die Sie k\u00fcrzlich erlebt haben, sowie Ihr Verhalten in dieser Situation. Sie werden auch einige Fragen zu Ihren Werten und Einstellung erhalten. Wenn Sie dies m\u00f6chten, erhalten Sie am Ende der Studie personalisierte Information zu Ihrer Pers\u00f6nlichkeit.",
+            "Alle Ihre Angaben werden vertraulich behandelt und lassen sich nur anhand einer Nummer (nicht anhand Ihres Namens) zuordnen. Diese anonymen Daten werden f\u00fcr Forschungszwecke in einer Online Datenbank archiviert, welche vom Zentrum f\u00fcr offene Wissenschaften (www.cos.io) verwaltet wird. Damit Sie Ihre Befragung abschliessen k\u00f6nnen, muss jede Frage beantwortet werden. Sie k\u00f6nnen Ihre Teilnahme an der Studie aber zu jedem Zeitpunkt abbrechen, ohne negative Konsequenzen. Der m\u00f6gliche Nutzen dieser Forschung ist es, Menschen und ihr Leben \u00fcber Kulturen hinweg besser zu verstehen. Es gibt keine bekannten Risiken.",
+            "Wenn Sie Fragen zu dieser Studie oder zu Ihren Rechten als TeilnehmerIn haben, k\u00f6nnen Sie gerne die koordinierende Person kontaktieren (Mathias Allemand, m.allemand@psychologie.uzh.ch, Universit\u00e4t Zurich), welche f\u00fcr die Datensammlung an Ihrem Ort zust\u00e4ndig ist. Auch k\u00f6nnen Sie das B\u00fcro der Forschungsintegrit\u00e4t der University of California, Riverside, per Email unter IRB@ucr.edu erreichen. Wir bedanken uns sehr f\u00fcr Ihre Mithilfe."
+        ],
+        "title": "Einverst\u00e4ndniserkl\u00e4rung zur Teilnahme an der Studie",
+        "versionHistory": "(Einverst\u00e4ndniserkl\u00e4rung: 14 October 2016)"
+    },
     "test": {
         "buttonLabel": "Please accept terms to continue",
         "consentLabel": "I have read and understand the above statements and agree to participate.",

--- a/app/locales/de/config.js
+++ b/app/locales/de/config.js
@@ -1,0 +1,16 @@
+// Ember-I18n includes configuration for common locales. Most users
+// can safely delete this file. Use it if you need to override behavior
+// for a locale or define behavior for a locale that Ember-I18n
+// doesn't know about.
+export default {
+  // rtl: [true|FALSE],
+  //
+  // pluralForm: function(count) {
+  //   if (count === 0) { return 'zero'; }
+  //   if (count === 1) { return 'one'; }
+  //   if (count === 2) { return 'two'; }
+  //   if (count < 5) { return 'few'; }
+  //   if (count >= 5) { return 'many'; }
+  //   return 'other';
+  // }
+};

--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -1,0 +1,1089 @@
+export default {
+    "0": "0",
+    "1": "1",
+    "10": "10",
+    "100": "100",
+    "11": "11",
+    "12": "12",
+    "13": "13",
+    "14": "14",
+    "15": "15",
+    "16": "16",
+    "17": "17",
+    "18": "18",
+    "19": "19",
+    "2": "2",
+    "20": "20",
+    "21": "21",
+    "22": "22",
+    "23": "23",
+    "24": "24",
+    "25": "25",
+    "26": "26",
+    "27": "27",
+    "28": "28",
+    "29": "29",
+    "3": "3",
+    "30": "30",
+    "31": "31",
+    "32": "32",
+    "33": "33",
+    "34": "34",
+    "35": "35",
+    "36": "36",
+    "37": "37",
+    "38": "38",
+    "39": "39",
+    "4": "4",
+    "40": "40",
+    "41": "41",
+    "42": "42",
+    "43": "43",
+    "44": "44",
+    "45": "45",
+    "46": "46",
+    "47": "47",
+    "48": "48",
+    "49": "49",
+    "5": "5",
+    "50": "50",
+    "51": "51",
+    "52": "52",
+    "53": "53",
+    "54": "54",
+    "55": "55",
+    "56": "56",
+    "57": "57",
+    "58": "58",
+    "59": "59",
+    "6": "6",
+    "60": "60",
+    "61": "61",
+    "62": "62",
+    "63": "63",
+    "64": "64",
+    "65": "65",
+    "66": "66",
+    "67": "67",
+    "68": "68",
+    "69": "69",
+    "7": "7",
+    "70": "70",
+    "71": "71",
+    "72": "72",
+    "73": "73",
+    "74": "74",
+    "75": "75",
+    "76": "76",
+    "77": "77",
+    "78": "78",
+    "79": "79",
+    "8": "8",
+    "80": "80",
+    "81": "81",
+    "82": "82",
+    "83": "83",
+    "84": "84",
+    "85": "85",
+    "86": "86",
+    "87": "87",
+    "88": "88",
+    "89": "89",
+    "9": "9",
+    "90": "90",
+    "91": "91",
+    "92": "92",
+    "93": "93",
+    "94": "94",
+    "95": "95",
+    "96": "96",
+    "97": "97",
+    "98": "98",
+    "99": "99",
+    "Key": "German Translation",
+    "exitpage": {
+        "line1": "Vielen Dank f\u00fcr Ihre Teilnahme!",
+        "line2": "Ihre Angaben wurden gespeichert."
+    },
+    "feedback": {
+        "agree": "Vertr\u00e4glichkeit",
+        "consc": "Gewissenhaftigkeit",
+        "exitButton": "Beenden",
+        "extra": "Extraversion",
+        "firstSection": "Basierend auf jahrzehntelanger Forschung sind sich Pers\u00f6nlichkeitspsychologen dar\u00fcber einig, dass die wichtigsten individuellen Unterschiede in Pers\u00f6nlichkeitseigenschaften anhand von f\u00fcnf grundlegenden Eigenschaften beschrieben werden k\u00f6nnen, bekannt als die \"Big Five\": Extraversion, Vertr\u00e4glichkeit, Gewissenhaftigkeit, emotionale Stabilit\u00e4t und Offenheit f\u00fcr Neues. Die Fragen, die Sie gerade beantwortet haben, liefern Werte f\u00fcr jede dieser Eigenschaften. Die Auswertung Ihrer Angaben ist untenstehend beschrieben.",
+        "fourthSection": "Vielen Dank f\u00fcr Ihre Teilnahme!",
+        "hiAgree": "Personen mit hohen Werten neigen dazu, r\u00fccksichtsvoll und h\u00f6flich in sozialen Begegnungen zu sein. Gerne kooperieren sie mit anderen Personen. Es f\u00e4llt ihnen leicht, anderen Personen zu vertrauen und f\u00fchlen mit bed\u00fcrftigen Personen mit. Personen mit hohen Werten werden von ihren Mitmenschen eher gemocht und bauen zufriedenstellende und stabile enge Beziehungen auf. Sie sind mit gr\u00f6sserer Wahrscheinlichkeit, religi\u00f6s, f\u00fchren Leitfunktionen im Gemeindewesen aus und \u00fcbernehmen Freiwilligenarbeit. \u00c4ltere Menschen zeigen in dieser Eigenschaft tendenziell h\u00f6here Werte als j\u00fcngere Menschen.",
+        "hiConsc": "Personen mit hohen Werten neigen dazu, organisiert und verantwortungsbewusst zu sein. Sie arbeiten hart, um ihre Ziele zu erreichen und schliessen die Dinge ab, die sie begonnen haben. Personen mit hohen Werten erreichen tendenziell bessere Noten in der Schule und vollbringen bessere Leistungen in vielen Berufen. Sie sind mit gr\u00f6sserer Wahrscheinlichkeit religi\u00f6s und haben konservative politische Einstellungen. Sie treiben tendenziell mehr Sport, haben eine bessere Gesundheit und leben l\u00e4nger. \u00c4ltere Menschen zeigen in dieser Eigenschaft tendenziell h\u00f6here Werte als j\u00fcngere Menschen.",
+        "hiExtra": "Personen mit hohen Werten neigen dazu, gespr\u00e4chig und tatkr\u00e4ftig zu sein. Sie sind gerne unter anderen Menschen und f\u00fchlen sich wohl dabei, sich einer Gruppe anzuschliessen. Personen mit hohen Werten tendieren dazu, mehr Freunde und Datingpartner zu haben und werden als beliebter eingesch\u00e4tzt. Sie f\u00fchren mit gr\u00f6sserer Wahrscheinlichkeit Leitfunktionen im Gemeindewesen aus und \u00fcbernehmen Freiwilligenarbeit. Sie neigen dazu, energievolle Musik zu m\u00f6gen, machen h\u00e4ufiger Sport und praktizieren mit gr\u00f6sserer Wahrscheinlichkeit eine Sportart. Sie erleben h\u00e4ufiger positive Emotionen und reagieren st\u00e4rker auf positive Ereignisse.",
+        "hiNeurot": "Personen mit hohen Werten neigen dazu, emotional stabil und belastbar zu sein. Sie bleiben \u00fcblicherweise ruhig, auch in stressreichen Situationen, und k\u00f6nnen nach negativen Ereignissen schnell wieder auf die Beine kommen. Menschen mit hohen Werten in emotionaler Stabilit\u00e4t zeigen tendenziell eine h\u00f6here Zufriedenheit.",
+        "hiOpen": "Personen mit hohen Werten sind grunds\u00e4tzlich offen f\u00fcr neue Aktivit\u00e4ten und neue Ideen. Sie sind tendenziell kreativ, intellektuell neugierig und empf\u00e4nglich f\u00fcr Kunst und f\u00fcr das Sch\u00f6ne. Menschen mit hohen Werten bevorzugen wissenschaftliche und k\u00fcnstlerische Berufe und sind besser in diesen Berufen. Sie bevorzugen klassische Musik sowie Jazz, Blues und Rockmusik.",
+        "labels": {
+            "high": "Hoch",
+            "low": "Tief",
+            "medium": "Mittel"
+        },
+        "loAgree": "Personen mit tiefen Werten dr\u00fccken sich direkt und unverbl\u00fcmt aus, auch wenn sie damit das Risiko eingehen, einen Streit vom Zaun zu brechen. Sie m\u00f6gen den Wettbewerb und tendieren dazu, skeptisch gegen\u00fcber den Absichten anderer Personen zu sein. Personen mit tiefen Werten verdienen tendenziell weniger und zeigen tendenziell risikohaftes Verhalten, wie Rauchen oder aggressives Fahren.",
+        "loConsc": "Personen mit tiefen Werten neigen dazu, eher spontan zu handeln als Pl\u00e4ne zu machen. Ihnen f\u00e4llt es leichter, die Aufmerksamkeit auf das grosse Ganze anstatt auf Details zu lenken. Sie bevorzugen es, zwischen Aufgaben zu wechseln, anstatt eine Aufgabe zu einem Zeitpunkt zu erledigen. Sie neigen dazu, risikohafteres Verhalten zu zeigen, wie Rauchen, Alkohol- oder Drogenkonsum.",
+        "loExtra": "Personen mit tiefen Werten neigen dazu, sozial und emotional reserviert zu sein. Im Allgemeinen bevorzugen sie es, alleine oder mit wenigen engen Freunden zusammen zu sein; ihre Meinungen und Gef\u00fchle behalten sie eher f\u00fcr sich. Sie nehmen seltener an aufregenden, Nervenkitzel suchenden Aktivit\u00e4ten teil und zeigen weniger risikohaftes Verhalten, wie Rauchen oder Alkoholkonsum.",
+        "loNeurot": "Personen mit tiefen Werten neigen dazu, emotional empfindsam zu sein und haben ihre auf- und absteigende Stimmungsschwankungen. Sie erleben h\u00e4ufiger negative Emotionen und reagieren st\u00e4rker auf negative Ereignisse. Junge Menschen haben tendenziell tiefere Werte als \u00e4ltere Menschen.",
+        "loOpen": "Personen mit tiefen Werten sind tendenziell traditionell und praktisch veranlagt und m\u00f6gen es, Dinge auf traditionelle Art und Weise zu tun. Sie ziehen das Vertraute dem Neuen vor und bevorzugen das Konkrete gegen\u00fcber dem Abstrakten. Menschen mit tiefen Werten bevorzugen konventionelle und praktische Berufe, wie Handwerk und Gewerbe, und sind besser in diesen Berufen.",
+        "neurot": "Emotionale Stabilit\u00e4t",
+        "open": "Offenheit f\u00fcr Neues",
+        "score": "Von 100 m\u00f6glichen Punkten ist Ihr Wert:",
+        "secondSection": "F\u00fcr jede der Eigenschaften gilt, dass Werte \u00fcber 60 hoch sind, w\u00e4hrend Werte unter 40 tief sind. Beschreibungen von hohen und tiefen Werten sind unten aufgef\u00fchrt. Wenn Ihr Wert zwischen 40 und 60 liegt, dann kann Ihre Pers\u00f6nlichkeit als durchschnittlich hinsichtlich der genannten Merkmalen beschrieben werden.",
+        "thirdSection": "Wir hoffen, dass Ihnen Ihre Teilnahme an dieser Studie gefallen hat.",
+        "title": "Ihre Pers\u00f6nlichkeit"
+    },
+    "flag": {
+        "chooseLanguage": "Bitte w\u00e4hlen Sie eine Sprache"
+    },
+    "global": {
+        "agreement": {
+            "agree": "Trifft zu",
+            "agreeStrongly": "Trifft v\u00f6llig zu",
+            "disagree": "Trifft nicht zu",
+            "disagreeStrongly": "Trifft gar nicht zu",
+            "neutral": "Neutral; keine Meinung"
+        },
+        "char": {
+            "extremelyChar": "Sehr charakteristisch",
+            "extremelyUnchar": "Sehr uncharakteristisch",
+            "fairlyChar": "Recht charakteristisch",
+            "fairlyUnchar": "Recht uncharakteristisch",
+            "neutral": "Weder charakteristisch noch uncharakteristisch",
+            "quiteChar": "Ziemlich charakteristisch",
+            "quiteUnchar": "Ziemlich uncharakteristisch",
+            "somewhatChar": "Ein wenig charakteristisch",
+            "somewhatUnchar": "Ein wenig uncharakteristisch"
+        },
+        "continueLabel": "Weiter",
+        "describe": {
+            "aGreatDeal": "Erheblich",
+            "aLittle": "Etwas",
+            "notAtAll": "Gar nicht"
+        },
+        "noLabel": "Nein",
+        "previousLabel": "Vorherige Seite",
+        "progress": "Fortschritt",
+        "selectUnselected": "Bitte w\u00e4hlen Sie",
+        "yesLabel": "Ja"
+    },
+    "login": {
+        "changeButton": "Sprache \u00e4ndern",
+        "defaultError": "Bitte versuchen Sie es sp\u00e4ter erneut",
+        "errorHeading": "Beim Anmelden ist ein Fehler aufgetreten",
+        "invalidAuthError": "Ung\u00fcltig Studien ID oder TeilnehmerIn ID",
+        "participantID": "TeilnehmerIn ID",
+        "studyID": "Studien ID",
+        "youChose": "Sie haben gew\u00e4hlt:"
+    },
+    "measures": {
+        "questions": {
+            "1": {
+                "label": "Insgesamt gesehen, war die von Ihnen beschriebene Situation eine positive oder eine negative Erfahrung?",
+                "options": {
+                    "extremelyNeg": "\u00c4ussert negativ",
+                    "extremelyPos": "\u00c4usserst positiv",
+                    "fairlyNeg": "Recht negativ",
+                    "fairlyPos": "Recht positiv",
+                    "neither": "Weder negativ noch positiv",
+                    "quiteNeg": "Ziemlich negativ",
+                    "quitePos": "Ziemlich positiv",
+                    "somewhatNeg": "Etwas negativ",
+                    "somewhatPos": "Etwas positiv"
+                }
+            },
+            "10": {
+                "items": {
+                    "1": {
+                        "label": "Es gibt viele soziale Normen in diesem Land, die die Menschen befolgen sollten."
+                    },
+                    "2": {
+                        "label": "In diesem Land gibt es sehr klare Erwartungen, wie sich Menschen in den meisten Situationen verhalten sollten."
+                    },
+                    "3": {
+                        "label": "In den meisten Situationen sind sich Menschen in diesem Land dar\u00fcber einig, welche Verhaltensweisen angemessen versus unangemessen sind."
+                    },
+                    "4": {
+                        "label": "Menschen in diesem Land haben in den meisten Situationen eine grosse Freiheit, zu entscheiden, wie sie sich verhalten wollen."
+                    },
+                    "5": {
+                        "label": "Wenn sich jemand in diesem Land in einer unangemessenen Art und Weise verh\u00e4lt, werden andere dies stark missbilligen."
+                    },
+                    "6": {
+                        "label": "Menschen in diesem Land halten so gut wie immer die soziale Normen ein."
+                    }
+                },
+                "label": "Bitte geben Sie an, wie sehr Sie den folgenden Aussagen zustimmen oder widersprechen.",
+                "options": {
+                    "agree": "Trifft zu / stimme zu",
+                    "agreeStrongly": "Trifft v\u00f6llig zu / stimme v\u00f6llig zu",
+                    "disagree": "Trifft nicht zu / Stimme nicht zu",
+                    "disagreeStrongly": "Trifft gar nicht zu / Stimme gar nicht zu",
+                    "neutral": "Neutral / keine Meinung"
+                }
+            },
+            "11": {
+                "label": "Gibt es einen Aspekt Ihrer Pers\u00f6nlichkeit, den Sie aktuell versuchen, zu \u00e4ndern?",
+                "options": {
+                    "no": "Nein",
+                    "yes": "Ja"
+                }
+            },
+            "12": {
+                "label": "Welchen Aspekt versuchen Sie zu \u00e4ndern?"
+            },
+            "13": {
+                "items": {
+                    "1": {
+                        "label": "Die meisten Menschen sind grunds\u00e4tzlich ehrlich."
+                    },
+                    "2": {
+                        "label": "Die meisten Menschen sind grunds\u00e4tzlich freundlich und nett"
+                    },
+                    "3": {
+                        "label": "Die meisten Menschen vertrauen anderen."
+                    },
+                    "4": {
+                        "label": "Im Allgemeinen vertraue ich anderen."
+                    },
+                    "5": {
+                        "label": "Die meisten Menschen sind vertrauensw\u00fcrdig."
+                    }
+                },
+                "label": "Bitte geben Sie an, wie sehr Sie den folgenden Aussagen zustimmen oder widersprechen:",
+                "options": {
+                    "agree": "Trifft zu / stimme zu",
+                    "agreeStrongly": "Trifft v\u00f6llig zu / stimme v\u00f6llig zu",
+                    "disagree": "Trifft nicht zu / Stimme nicht zu",
+                    "disagreeStrongly": "Trifft gar nicht zu / Stimme gar nicht zu",
+                    "neutral": "Neutral / keine Meinung"
+                }
+            },
+            "14": {
+                "items": {
+                    "1": {
+                        "label": "In Zeiten der Ungewissheit erwarte ich \u00fcblicherweise das Beste."
+                    },
+                    "2": {
+                        "label": "Wenn etwas f\u00fcr mich schief gehen kann, dann geht es schief."
+                    },
+                    "3": {
+                        "label": "Ich bin immer optimistisch hinsichtlich meiner Zukunft."
+                    },
+                    "4": {
+                        "label": "Ich erwarte fast nie, dass Dinge nach meinen Vorstellungen laufen."
+                    },
+                    "5": {
+                        "label": "Ich rechne selten damit, dass mir gute Dinge passieren."
+                    },
+                    "6": {
+                        "label": "Insgesamt erwarte ich, dass mir mehr gute als schlechte Dinge passieren."
+                    }
+                },
+                "label": "Bitte geben Sie an, wie sehr Sie den folgenden Aussagen zustimmen oder widersprechen:",
+                "options": {
+                    "agree": "Trifft zu / stimme zu",
+                    "agreeStrongly": "Trifft v\u00f6llig zu / stimme v\u00f6llig zu",
+                    "disagree": "Trifft nicht zu / Stimme nicht zu",
+                    "disagreeStrongly": "Trifft gar nicht zu / Stimme gar nicht zu",
+                    "neutral": "Neutral / keine Meinung"
+                }
+            },
+            "15": {
+                "items": {
+                    "1": {
+                        "label": "Ich w\u00fcrde keine Schmeichelei anwenden, um eine Gehaltserh\u00f6hung oder eine Bef\u00f6rderung bei der Arbeit zu erhalten. Auch dann nicht, wenn ich denke, dass ich damit durchkommen w\u00fcrde."
+                    },
+                    "10": {
+                        "label": "Ich m\u00f6chte, dass andere Menschen wissen, dass ich eine wichtige Person von hohem Status bin."
+                    },
+                    "2": {
+                        "label": "Wenn ich etwas von einer anderen Person m\u00f6chte, werde ich selbst bei ihren schlechtesten Witzen lachen."
+                    },
+                    "3": {
+                        "label": "Ich w\u00fcrde nicht so tun, als ob ich jemanden mag, nur damit mir diese Person einen Gefallen macht."
+                    },
+                    "4": {
+                        "label": "Wenn ich w\u00fcsste, dass ich niemals gefasst werden w\u00fcrde, w\u00e4re ich bereit, einen grossen Geldbetrag zu stehlen."
+                    },
+                    "5": {
+                        "label": "Ich w\u00fcrde nie Bestechungsgeld annehmen, auch wenn es sehr viel w\u00e4re."
+                    },
+                    "6": {
+                        "label": "Ich w\u00e4re versucht, Falschgeld zu verwenden, wenn ich sicher sein k\u00f6nnte, dass ich damit durchkommen w\u00fcrde."
+                    },
+                    "7": {
+                        "label": "Viel Geld zu haben ist nicht besonders wichtig f\u00fcr mich."
+                    },
+                    "8": {
+                        "label": "Ich w\u00fcrde sehr viel Freude versp\u00fcren, wenn ich viele teure Luxusg\u00fcter besitzen w\u00fcrde."
+                    },
+                    "9": {
+                        "label": "Ich denke, dass mir mehr Respekt zusteht als einer Durchschnittsperson."
+                    }
+                },
+                "label": "Bitte geben Sie an, wie sehr Sie den folgenden Aussagen zustimmen oder widersprechen:",
+                "options": {
+                    "agree": "Trifft zu / stimme zu",
+                    "agreeStrongly": "Trifft v\u00f6llig zu / stimme v\u00f6llig zu",
+                    "disagree": "Trifft nicht zu / Stimme nicht zu",
+                    "disagreeStrongly": "Trifft gar nicht zu / Stimme gar nicht zu",
+                    "neutral": "Neutral / keine Meinung"
+                }
+            },
+            "16": {
+                "items": {
+                    "1": {
+                        "label": "mit der Familie"
+                    },
+                    "2": {
+                        "label": "mit Freunden"
+                    },
+                    "3": {
+                        "label": "in der Stadt, in der ich wohne"
+                    },
+                    "4": {
+                        "label": "in der Gesellschaft"
+                    },
+                    "5": {
+                        "label": "in der Welt"
+                    }
+                },
+                "label": "Wie stark haben Sie das Gef\u00fchl, dass sich Ihr Leben in den folgenden Bereichen entwickelt?",
+                "options": {
+                    "aLittle": "Etwas",
+                    "completely": "Komplett",
+                    "notAtAll": "Gar nicht",
+                    "quiteaBit": "Ziemlich"
+                }
+            },
+            "17": {
+                "items": {
+                    "1": {
+                        "label": "Ich verdiene es, als eine grossartige Person gesehen zu werden."
+                    },
+                    "2": {
+                        "label": "Eine sehr besondere Person zu sein, gibt mir viel St\u00e4rke."
+                    },
+                    "3": {
+                        "label": "Mit meinen herausragenden Beitr\u00e4gen schaffe ich es, im Mittelpunkt der Aufmerksamkeit zu stehen."
+                    },
+                    "4": {
+                        "label": "Alle Menschen sind zu einem gewissen Grad Verlierer."
+                    },
+                    "5": {
+                        "label": "Ich m\u00f6chte, dass meine Gegner versagen."
+                    },
+                    "6": {
+                        "label": "Ich reagiere genervt, wenn mir eine andere Person die Show stiehlt."
+                    }
+                },
+                "label": "Bitte geben Sie an, wie sehr Sie den folgenden Aussagen zustimmen oder widersprechen:",
+                "options": {
+                    "agree": "Trifft zu / stimme zu",
+                    "agreeStrongly": "Trifft v\u00f6llig zu / stimme v\u00f6llig zu",
+                    "disagree": "Trifft nicht zu / Stimme nicht zu",
+                    "disagreeStrongly": "Trifft gar nicht zu / Stimme gar nicht zu",
+                    "neutral": "Neutral / keine Meinung"
+                }
+            },
+            "18": {
+                "label": "Wie erfolgreich waren Sie darin, diesen Aspekt Ihrer Pers\u00f6nlichkeit zu \u00e4ndern?",
+                "options": {
+                    "alittleSuccessful": "Bisschen erfolgreich",
+                    "completelySuccessful": "Komplett erfolgreich",
+                    "moderatelySuccessful": "Mittelm\u00e4ssig erfolgreich",
+                    "notatallSuccessful": "Gar nicht erfolgreich",
+                    "verySuccessful": "Sehr erfolgreich"
+                }
+            },
+            "2": {
+                "label": "Wie oft erleben Sie Situationen, die jener von Ihnen beschriebenen Situation \u00e4hnlich sind?",
+                "options": {
+                    "hardlyEver": "Fast nie",
+                    "never": "Nie",
+                    "occasionally": "Gelegentlich",
+                    "quiteOften": "Recht oft"
+                }
+            },
+            "3": {
+                "items": {
+                    "1": {
+                        "label": "Ich habe versucht, die Situation zu kontrollieren."
+                    },
+                    "10": {
+                        "label": "Ich was k\u00f6rperlich belebt, bin herumgelaufen."
+                    },
+                    "11": {
+                        "label": "Ich habe mich f\u00fcr das interessiert, was jemand zu sagen hatte."
+                    },
+                    "12": {
+                        "label": "Ich habe Rat gesucht."
+                    },
+                    "13": {
+                        "label": "Ich habe mich spielerisch verhalten."
+                    },
+                    "14": {
+                        "label": "Ich habe Selbstmitleid oder Gef\u00fchle des Opferseins gezeigt."
+                    },
+                    "15": {
+                        "label": "Ich habe mit lauter Stimme gesprochen."
+                    },
+                    "16": {
+                        "label": "Ich habe ein hohes Mass an Intelligenz gezeigt."
+                    },
+                    "2": {
+                        "label": "Ich habe negative Dinge \u00fcber mich gesagt."
+                    },
+                    "3": {
+                        "label": "Ich habe mich in einer kompetitiven Art und Weise verhalten."
+                    },
+                    "4": {
+                        "label": "Ich habe Ehrgeiz gezeigt."
+                    },
+                    "5": {
+                        "label": "Ich habe die Situation beherrscht."
+                    },
+                    "6": {
+                        "label": "Ich habe hohen Enthusiasmus und ein hohes Level an Energie gezeigt."
+                    },
+                    "7": {
+                        "label": "Ich habe mich in k\u00f6rperlicher Aktivit\u00e4t bet\u00e4tigt."
+                    },
+                    "8": {
+                        "label": "Ich habe mich auf eine Aufgabe konzentriert oder hart an einer Aufgabe gearbeitet."
+                    },
+                    "9": {
+                        "label": "Ich war zur\u00fcckhaltend und ausdruckslos."
+                    }
+                },
+                "label": "Bitte beurteilen Sie Ihr Verhalten in der Situation, die Sie beschrieben haben:",
+                "options": {
+                    "extremelyChar": "Sehr charakteristisch",
+                    "extremelyUnchar": "Sehr uncharakteristisch/untypisch",
+                    "fairlyChar": "Recht charakteristisch",
+                    "fairlyUnchar": "Recht uncharakteristisch",
+                    "neutral": "Weder charakteristisch noch uncharakteristisch",
+                    "quiteChar": "Ziemlich charakteristisch",
+                    "quiteUnchar": "Ziemlich uncharakteristisch",
+                    "somewhatChar": "Ein wenig charakteristisch",
+                    "somewhatUnchar": "Ein wenig uncharakteristisch"
+                }
+            },
+            "4": {
+                "label": "Wie sehen Sie sich selbst: Sind Sie grunds\u00e4tzlich eine Person, die bereit ist, Risiken einzugehen oder versuchen Sie, das Eingehen von Risiken zu vermeiden?",
+                "options": {
+                    "fullyPrepared": "risikofreudig",
+                    "unwilling": "risikoscheu"
+                }
+            },
+            "5": {
+                "items": {
+                    "1": {
+                        "label": "Ich gehe aus mir heraus, bin gesellig."
+                    },
+                    "10": {
+                        "label": "Ich bin vielseitig interessiert."
+                    },
+                    "11": {
+                        "label": "Ich sch\u00e4ume selten vor Begeisterung \u00fcber."
+                    },
+                    "12": {
+                        "label": "Ich neige dazu, andere zu kritisieren."
+                    },
+                    "13": {
+                        "label": "Ich bin stetig, best\u00e4ndig."
+                    },
+                    "14": {
+                        "label": "Ich kann launisch sein, habe schwankende\nStimmungen."
+                    },
+                    "15": {
+                        "label": "Ich bin erfinderisch, mir fallen raffinierte\nL\u00f6sungen ein."
+                    },
+                    "16": {
+                        "label": "Ich bin eher ruhig."
+                    },
+                    "17": {
+                        "label": "Ich habe mit anderen wenig Mitgef\u00fchl."
+                    },
+                    "18": {
+                        "label": "Ich bin systematisch, halte meine Sachen in\nOrdnung."
+                    },
+                    "19": {
+                        "label": "Ich reagiere leicht angespannt."
+                    },
+                    "2": {
+                        "label": "Ich bin einf\u00fchlsam, warmherzig"
+                    },
+                    "20": {
+                        "label": "Ich kann mich f\u00fcr Kunst, Musik und Literatur\nbegeistern."
+                    },
+                    "21": {
+                        "label": "Ich neige dazu, die F\u00fchrung zu \u00fcbernehmen."
+                    },
+                    "22": {
+                        "label": "Ich habe oft Streit mit anderen."
+                    },
+                    "23": {
+                        "label": "Ich neige dazu, Aufgaben vor mir herzuschieben."
+                    },
+                    "24": {
+                        "label": "Ich bin selbstsicher, mit mir zufrieden."
+                    },
+                    "25": {
+                        "label": "Ich meide philosophische Diskussionen."
+                    },
+                    "26": {
+                        "label": "Ich bin weniger aktiv und unternehmungslustig\nals andere."
+                    },
+                    "27": {
+                        "label": "Ich bin nachsichtig, vergebe anderen leicht."
+                    },
+                    "28": {
+                        "label": "Ich bin manchmal ziemlich nachl\u00e4ssig."
+                    },
+                    "29": {
+                        "label": "Ich bin ausgeglichen, nicht leicht aus der Ruhe zu bringen."
+                    },
+                    "3": {
+                        "label": "Ich bin eher unordentlich."
+                    },
+                    "30": {
+                        "label": "Ich bin nicht besonders einfallsreich."
+                    },
+                    "31": {
+                        "label": "Ich bin eher sch\u00fcchtern."
+                    },
+                    "32": {
+                        "label": "Ich bin hilfsbereit und selbstlos."
+                    },
+                    "33": {
+                        "label": "Ich mag es sauber und aufger\u00e4umt."
+                    },
+                    "34": {
+                        "label": "Ich mache mir oft Sorgen."
+                    },
+                    "35": {
+                        "label": "Kunst und Sch\u00f6nes wertsch\u00e4tzt"
+                    },
+                    "36": {
+                        "label": "Ich wei\u00df Kunst und Sch\u00f6nheit zu sch\u00e4tzen."
+                    },
+                    "37": {
+                        "label": "Ich bin manchmal unh\u00f6flich und schroff"
+                    },
+                    "38": {
+                        "label": "Ich bin effizient, erledige Dinge schnell."
+                    },
+                    "39": {
+                        "label": "Ich bin effizient, erledige Dinge schnell."
+                    },
+                    "4": {
+                        "label": "Ich bleibe auch in stressigen Situationen\ngelassen."
+                    },
+                    "40": {
+                        "label": "Es macht mir Spa\u00df, gr\u00fcndlich \u00fcber komplexe Dinge nachzudenken und sie zu verstehen."
+                    },
+                    "41": {
+                        "label": "Ich bin voller Energie und Tatendrang."
+                    },
+                    "42": {
+                        "label": "Ich bin anderen gegen\u00fcber misstrauisch."
+                    },
+                    "43": {
+                        "label": "Ich bin verl\u00e4sslich, auf mich kann man z\u00e4hlen."
+                    },
+                    "44": {
+                        "label": "Ich habe meine Gef\u00fchle unter Kontrolle, werde selten w\u00fctend."
+                    },
+                    "45": {
+                        "label": "Ich bin nicht sonderlich fantasievoll."
+                    },
+                    "46": {
+                        "label": "Ich bin gespr\u00e4chig."
+                    },
+                    "47": {
+                        "label": "Andere sind mir eher gleichg\u00fcltig, egal."
+                    },
+                    "48": {
+                        "label": "Ich bin eher der chaotische Typ, mache selten sauber."
+                    },
+                    "49": {
+                        "label": "Ich werde selten nerv\u00f6s und unsicher."
+                    },
+                    "5": {
+                        "label": "Ich bin nicht sonderlich kunstinteressiert."
+                    },
+                    "50": {
+                        "label": "Ich finde Gedichte und Theaterst\u00fccke langweilig."
+                    },
+                    "51": {
+                        "label": "In einer Gruppe \u00fcberlasse ich lieber anderen die Entscheidung."
+                    },
+                    "52": {
+                        "label": "Ich bin h\u00f6flich und zuvorkommend."
+                    },
+                    "53": {
+                        "label": "Ich bleibe an einer Aufgabe dran, bis sie erledigt ist."
+                    },
+                    "54": {
+                        "label": "Ich bin oft deprimiert, niedergeschlagen."
+                    },
+                    "55": {
+                        "label": "Mich interessieren abstrakte \u00dcberlegungen\nwenig."
+                    },
+                    "56": {
+                        "label": "Ich bin begeisterungsf\u00e4hig und kann andere\nleicht mitrei\u00dfen."
+                    },
+                    "57": {
+                        "label": "Ich schenke anderen leicht Vertrauen, glaube an das Gute im Menschen."
+                    },
+                    "58": {
+                        "label": "Manchmal verhalte ich mich verantwortungslos, leichtsinnig."
+                    },
+                    "59": {
+                        "label": "Ich reagiere schnell gereizt oder genervt."
+                    },
+                    "6": {
+                        "label": "Ich bin durchsetzungsf\u00e4hig, energisch."
+                    },
+                    "60": {
+                        "label": "Ich bin originell, entwickle neue Ideen."
+                    },
+                    "7": {
+                        "label": "Ich begegne anderen mit Respekt."
+                    },
+                    "8": {
+                        "label": "Ich bin bequem, neige zu Faulheit."
+                    },
+                    "9": {
+                        "label": "Ich bleibe auch bei R\u00fcckschl\u00e4gen zuversichtlich."
+                    }
+                },
+                "label": "Bitte geben Sie f\u00fcr jede der folgenden Aussagen an, inwieweit Sie zustimmen.\n",
+                "options": {
+                    "agree": "Stimme eher zu",
+                    "agreeStrongly": "Trifft v\u00f6llig zu",
+                    "disagree": "Stimme eher nicht zu",
+                    "disagreeStrongly": "Stimme \u00fcberhaupt nicht zu",
+                    "neutral": "Teils, teils"
+                }
+            },
+            "6": {
+                "items": {
+                    "1": {
+                        "label": "Im Allgemeinen betrachte ich mich selbst",
+                        "options": {
+                            "notHappy": "Keine sehr gl\u00fcckliche Person",
+                            "veryHappy": "Eine sehr gl\u00fcckliche Person"
+                        }
+                    },
+                    "2": {
+                        "label": "Verglichen mit den meisten Menschen um mich herum, sehe ich mich selbst:",
+                        "options": {
+                            "lessHappy": "weniger gl\u00fccklich",
+                            "moreHappy": "gl\u00fccklicher"
+                        }
+                    },
+                    "3": {
+                        "label": "Manche Menschen sind grunds\u00e4tzlich sehr gl\u00fccklich. Unabh\u00e4ngig davon, was passiert, geniessen Sie Ihr Leben und holen das Meiste aus allem heraus. Wie sehr trifft diese Beschreibung auf Sie zu?",
+                        "options": {
+                            "aGreatDeal": "Erheblich",
+                            "notAtAll": "Gar nicht"
+                        }
+                    },
+                    "4": {
+                        "label": "Manche Menschen sind grunds\u00e4tzlich nicht sehr gl\u00fccklich. Obwohl Sie nicht niedergeschlagen sind, scheinen sie nie so gl\u00fccklich, wie sie sein k\u00f6nnten. Wie sehr trifft diese Beschreibung auf Sie zu?",
+                        "options": {
+                            "aGreatDeal": "Erheblich",
+                            "notAtAll": "Gar nicht"
+                        }
+                    }
+                },
+                "label": "Bitte geben Sie f\u00fcr jede der folgenden Fragen auf einer 7-stufigen Skala jene Stelle an, die Sie am besten beschreibt."
+            },
+            "7": {
+                "items": {
+                    "1": {
+                        "label": "Ich glaube, dass ich und die Menschen um mich gl\u00fccklich sind"
+                    },
+                    "2": {
+                        "label": "Ich habe das Gef\u00fchl, dass ich von anderen um mich herum positiv bewertet werde"
+                    },
+                    "3": {
+                        "label": "Ich mache wichtige Menschen um mich herum gl\u00fccklich"
+                    },
+                    "4": {
+                        "label": "Obwohl es ziemlich durchschnittlich ist, lebe ich ein best\u00e4ndiges Leben"
+                    },
+                    "5": {
+                        "label": "Ich habe keine gr\u00f6sseren Sorgen oder \u00c4ngste"
+                    },
+                    "6": {
+                        "label": "Ich kann machen, was ich m\u00f6chte, ohne dadurch Probleme f\u00fcr andere Menschen zu erzeugen"
+                    },
+                    "7": {
+                        "label": "Ich glaube, dass mein Leben genauso gl\u00fccklich ist, wie jenes von anderen Menschen um mich"
+                    },
+                    "8": {
+                        "label": "Ich glaube, dass ich den gleichen Lebensstandard erreicht habe, wie jene um mich"
+                    },
+                    "9": {
+                        "label": "Grunds\u00e4tzlich glaube ich, dass die Dinge f\u00fcr mich genauso gut laufen, wie f\u00fcr andere Menschen um mich"
+                    }
+                },
+                "label": "Bitte geben Sie an, wie sehr Sie den folgenden Aussagen zustimmen oder widersprechen",
+                "options": {
+                    "agree": "Trifft zu / stimme zu",
+                    "agreeStrongly": "Trifft v\u00f6llig zu / stimme v\u00f6llig zu",
+                    "disagree": "Trifft nicht zu / Stimme nicht zu",
+                    "disagreeStrongly": "Trifft gar nicht zu / Stimme gar nicht zu",
+                    "neutral": "Neutral / keine Meinung"
+                }
+            },
+            "8": {
+                "items": {
+                    "1": {
+                        "label": "Der Glaube in eine Religion hilft dabei, den Sinn des Lebens zu verstehen"
+                    },
+                    "10": {
+                        "label": "Nur schwache Personen brauchen eine Religion"
+                    },
+                    "11": {
+                        "label": "Durch Religion kann man der Realit\u00e4t entfliehen"
+                    },
+                    "12": {
+                        "label": "Das Praktizieren einer Religion vereint Menschen untereinander"
+                    },
+                    "13": {
+                        "label": "Religi\u00f6se Menschen werden mit gr\u00f6sserer Wahrscheinlichkeit, moralische Standards einhalten"
+                    },
+                    "14": {
+                        "label": "Religi\u00f6se Glaubenss\u00e4tze f\u00fchren zu unwissenschaftlichem Denken"
+                    },
+                    "15": {
+                        "label": "Ignoranz l\u00e4sst Menschen an ein h\u00f6heres Wesen glauben"
+                    },
+                    "16": {
+                        "label": "Der Beweis eines h\u00f6heren Wesens ist f\u00fcr jene, die solche Zeichen suchen, \u00fcberall pr\u00e4sent"
+                    },
+                    "17": {
+                        "label": "Religion widerspricht Wissenschaft"
+                    },
+                    "2": {
+                        "label": "Religion hilft dabei, dass Menschen gute Entscheidungen f\u00fcr ihr Leben treffen"
+                    },
+                    "3": {
+                        "label": "Gl\u00e4ubigkeit tr\u00e4gt zu einer guten geistigen Gesundheit bei"
+                    },
+                    "4": {
+                        "label": "Religion l\u00e4sst menschlichen Fortschritt langsamer werden"
+                    },
+                    "5": {
+                        "label": "Es existiert ein h\u00f6heres Wesen, welches das Universum kontrolliert"
+                    },
+                    "6": {
+                        "label": "Religion macht Menschen ges\u00fcnder"
+                    },
+                    "7": {
+                        "label": "Religion macht Menschen gl\u00fccklicher"
+                    },
+                    "8": {
+                        "label": "Der Glaube in eine Religion macht Menschen zu besseren B\u00fcrgern"
+                    },
+                    "9": {
+                        "label": "Religi\u00f6se Praxis macht es Menschen schwerer, unabh\u00e4ngig zu denken"
+                    }
+                },
+                "label": "Bitte geben Sie an, wie sehr Sie den folgenden Aussagen zustimmen oder widersprechen",
+                "options": {
+                    "believeLittle": "Etwas zu glauben",
+                    "believeStrong": "Sehr zu glauben",
+                    "disbelieveLittle": "Etwas zu bezweifeln",
+                    "disbelieveStrong": "Sehr zu bezweifeln",
+                    "neutral": "Neutral / keine Meinung",
+                    "preferNoAnswer": "Ich m\u00f6chte die Frage lieber nicht beantworten."
+                }
+            },
+            "9": {
+                "items": {
+                    "1": {
+                        "label": "Sie bevorzugen es, Ihre Gedanken und Gef\u00fchle offen auszudr\u00fccken, auch wenn dies Konflikte hervorbringen kann."
+                    },
+                    "10": {
+                        "label": "Sie verhalten sich unterschiedlich, wenn Sie mit unterschiedlichen Personen zusammen sind."
+                    },
+                    "11": {
+                        "label": "Sie sehen sich selbst anders, wenn Sie mit verschiedenen Personen zusammen sind."
+                    },
+                    "12": {
+                        "label": "Sie sehen sich selbst auf die gleiche Art und Weise, auch wenn Sie in verschiedenen sozialen Umgebungen sind."
+                    },
+                    "13": {
+                        "label": "Sie verhalten sich in der gleichen Weise, auch wenn Sie mit verschiedenen Personen zusammen sind."
+                    },
+                    "2": {
+                        "label": "Sie versuchen, sich Ihren Mitmenschen anzupassen, auch wenn dies bedeutet, dass Sie Ihre Gef\u00fchle verbergen."
+                    },
+                    "3": {
+                        "label": "Sie bevorzugen es, die Harmonie in Ihren Beziehungen zu wahren, auch wenn dies bedeutet, dass Sie nicht Ihre wahren Gef\u00fchle zeigen."
+                    },
+                    "4": {
+                        "label": "Sie denken, dass es gut ist, offen zu zeigen, wenn Sie mit anderen Personen nicht \u00fcbereinstimmen."
+                    },
+                    "5": {
+                        "label": "Sie wahren Ihre eigenen Interessen, auch wenn dies manchmal Ihre famil\u00e4ren Beziehungen beeintr\u00e4chtigen kann."
+                    },
+                    "6": {
+                        "label": "F\u00fcr gew\u00f6hnlich geben Sie anderen den Vorrang, anstatt Ihnen selbst."
+                    },
+                    "7": {
+                        "label": "Sie k\u00fcmmern sich um die Ihnen nahestehenden Personen, auch wenn dies bedeutet, dass Sie Ihre pers\u00f6nlichen Belange zur Seite stellen."
+                    },
+                    "8": {
+                        "label": "Sie werten pers\u00f6nliche Leistungen h\u00f6her als gute Beziehungen zu den Personen, die Ihnen nahe sind."
+                    },
+                    "9": {
+                        "label": "Sie w\u00fcrden Ihre pers\u00f6nlichen Interessen zum Wohle Ihrer Familie aufgeben."
+                    }
+                },
+                "label": "Wie gut beschreibt jede dieser Aussage Sie?",
+                "options": {
+                    "aLittle": "Bescheibt mich ein wenig",
+                    "exactly": "Beschreibt mich genau",
+                    "moderately": "Beschreibt mich m\u00e4ssig",
+                    "notAtAll": "Beschreibt mich gar nicht",
+                    "veryWell": "Beschreibt mich sehr gut"
+                }
+            }
+        }
+    },
+    "previouslogin": {
+        "line1": "Unsere Daten geben an, dass Sie die Studie bereits abgeschlossen haben.",
+        "line2": "Wenn dies eine fehlerhafte Angabe ist, kontaktieren Sie bitte Ihren lokalen Koordinator des Internationalen Situationen Projekts."
+    },
+    "qsort": {
+        "rsq": {
+            "item": {
+                "SomoneCountedon": "Es wird darauf gez\u00e4hlt, dass eine anwesende Person (jemand anderes als Sie), etwas tut",
+                "abusedVictimized": "Sie werden missbraucht oder schikaniert.",
+                "adviceYou": "Andere wollen Rat von Ihnen.",
+                "ambition": "Ehrgeiz kann ausgedr\u00fcckt oder bewiesen werden.",
+                "anxietyInducing": "Die Situation ist potenziell angsteinfl\u00f6ssend.",
+                "art": "Kunst ist ein wichtiger Bestandteil der Situation.",
+                "askingYou": "Jemand bittet Sie um etwas.",
+                "assertivenessGoal": "Durchsetzungsverm\u00f6gen ist n\u00f6tig, um ein Ziel zu erreichen.",
+                "athleticsSports": "Menschen betreiben Sportaktivit\u00e4ten.",
+                "blaming": "Jemand beschuldigt Sie f\u00fcr etwas.",
+                "breakingRules": "Jemand bricht die Regeln.",
+                "clearRules": "Klare Regeln erfordern ein angemessenes Verhalten (ob die Regeln befolgt werden oder nicht).",
+                "closeRelationships": "Die anwesenden Personen stehen in nahen Beziehungen zueinander.",
+                "comparingThemselves": "Personen vergleichen sich miteinander.",
+                "competing": "Menschen stehen miteinander im Wettkampf / konkurrieren miteinander.",
+                "complex": "Die Situation ist komplex.",
+                "complimentingYou": "Jemand macht Ihnen ein Kompliment oder lobt Sie.",
+                "conformToOthers": "Sie werden unter Druck gesetzt, mit Handlungen anderer Personen \u00fcbereinzustimmen.",
+                "convinceYou": "Jemand versucht, Sie von etwas zu \u00fcberzeugen.",
+                "countingOnYou": "Jemand ist darauf angewiesen, dass Sie etwas tun.",
+                "criticizing": "Jemand kritisiert Sie.",
+                "decision": "Eine Entscheidung muss getroffen werden.",
+                "desiresGratified": "Bed\u00fcrfnisse k\u00f6nnen gestillt werden (zum Beispiel: Essen, Shoppen, sexuelle Gelegenheiten).",
+                "differentRoles": "Die anwesenden Personen nehmen verschiedene soziale Rollen oder Stufen von Status ein.",
+                "disagreeing": "Personen sind sich uneinig \u00fcber etwas.",
+                "dominate": "Jemand versucht, Sie zu dominieren oder herumzukommandieren.",
+                "emotionalThreats": "Emotionale Bedrohungen sind pr\u00e4sent.",
+                "emotionsExpressed": "Gef\u00fchle k\u00f6nnen ausgedr\u00fcckt werden.",
+                "entertainment": "Unterhaltungsangebote sind vorhanden.",
+                "family": "Familie ist wichtig in dieser Situation.",
+                "feelInadequate": "Die Situation k\u00f6nnte bewirken, dass Sie sich unangepasst f\u00fchlen.",
+                "femininity": "Femininit\u00e4t kann ausgedr\u00fcckt werden.",
+                "food": "Essen ist wichtig f\u00fcr diese Situation.",
+                "frustrating": "Die Situation ist frustrierend (zum Beispiel: ein Ziel ist blockiert).",
+                "goodImpression": "Es ist wichtig f\u00fcr Sie, einen guten Eindruck abzugeben.",
+                "happeningOnce": "Viele Dinge passieren gleichzeitig.",
+                "honor": "Eine Frage der Ehre steht auf dem Spiel.",
+                "hostile": "Die Situation k\u00f6nnte Menschen sich feindselig f\u00fchlen lassen.",
+                "humorous": "Die Situation ist humorvoll oder potenziell humorvoll.",
+                "intellectuallyStimulating": "Die Situation k\u00f6nnte intellektuell stimulierend sein.",
+                "intelligence": "Intelligenz ist wichtig (zum Beispiel: eine intellektuelle Diskussion oder ein komplexes Problem, das gel\u00f6st werden muss).",
+                "jobDone": "Eine Arbeit muss erledigt werden.",
+                "masculinity": "Maskulinit\u00e4t kann ausgedr\u00fcckt werden.",
+                "minorDetails": "Kleine Details sind wichtig.",
+                "money": "Geld ist wichtig.",
+                "moralIssues": "Moralische oder ethische Themen sind relevant.",
+                "music": "Musik ist ein wichtiger Bestandteil dieser Situation.",
+                "needsHelp": "Jemand braucht Hilfe.",
+                "negativeEmotions": "Die Situation k\u00f6nnte negative Emotionen hervorrufen.",
+                "newRelationships": "Neue Beziehungen k\u00f6nnen entstehen.",
+                "noisy": "Die Situation ist ger\u00e4uschvoll (eine geringe Platzierung dieses Elements bedeutet, dass die Situation sehr leise ist).",
+                "notClear": "Es ist nicht klar, was passiert; Die Situation ist ungewiss.",
+                "oppositeSex": "Die Anwesenheit von Personen des anderen Geschlechts ist ein wichtiger Bestandteil dieser Situation.",
+                "peopleGetAlong": "F\u00fcr die anwesenden Menschen ist es wichtig, gut miteinander auszukommen.",
+                "physicalAttractiveness": "Ihre \u00e4usserliche Attraktivit\u00e4t ist wichtig.",
+                "physicalThreats": "K\u00f6rperliche Bedrohungen sind pr\u00e4sent.",
+                "physicallyActive": "Menschen sind k\u00f6rperlich aktiv.",
+                "physicallyUncomfortable": "Die Situation ist k\u00f6rperlich unangenehm (zum Beispiel: zu heiss, zu belebt, zu kalt, etc.). (Eine tiefe Einstufung dieses Elements bedeutet, dass die Situation k\u00f6rperlich sehr angenehm ist).",
+                "playful": "Die Situation ist spielerisch.",
+                "politics": "Politik ist wichtig (zum Beispiel: eine politische Diskussion).",
+                "positiveEmotions": "Die Situation k\u00f6nnte positive Emotionen hervorrufen.",
+                "potentiallyEnjoy": "Die Situation ist potenziell angenehm.",
+                "power": "Macht ist wichtig.",
+                "quickAction": "Schnelle Handlung ist notwendig.",
+                "rapidlyChanging": "Die Situation \u00e4ndert sich schnell.",
+                "reassurance": "Jemand braucht oder w\u00fcnscht Beruhigung.",
+                "reassuringPresent": "Eine beruhigende Person ist anwesend.",
+                "relevantHealth": "Die Situation ist wichtig f\u00fcr Ihre Gesundheit (zum Beispiel: M\u00f6glichkeit einer Krankheit, ein Arztbesuch).",
+                "religion": "Religion ist relevant in dieser Situation (zum Beispiel: ein Gottesdienst oder eine Diskussion).",
+                "romanticPartners": "M\u00f6gliche oder tats\u00e4chliche romantische Partner (f\u00fcr Sie) sind anwesend.",
+                "ruminateDaydream": "Es ist m\u00f6glich, zu gr\u00fcbeln, Tag zu tr\u00e4umen oder zu fantasieren.",
+                "selfControl": "Selbstkontrolle ist notwendig (f\u00fcr Sie oder f\u00fcr andere).",
+                "sensations": "Sinne sind wichtig (zum Beispiel: Ber\u00fchrung, Geschmack, Geruch, k\u00f6rperlicher Kontakt).",
+                "sexuality": "Sexualit\u00e4t ist relevant.",
+                "shame": "Jemand f\u00fchlt sich besch\u00e4mt.",
+                "simpleClearcut": "Die Situation ist einfach und eindeutig.",
+                "smallAnnoyances": "Die Situation beinhaltet kleine \u00c4rgernisse.",
+                "socialInteraction": "Soziale Interaktion ist m\u00f6glich.",
+                "successCooperation": "Erfolg erfordert Kooperation.",
+                "takenCareOf": "Jemand ben\u00f6tigt F\u00fcrsorge.",
+                "talkingExpected": "Reden ist erwartet oder verlangt.",
+                "talkingPermitted": "Reden ist verboten.",
+                "tenseUpset": "Die Situation k\u00f6nnte Menschen angespannt und ver\u00e4rgert machen.",
+                "tryingImpress": "Jemand versucht, Sie zu beeindrucken.",
+                "underThreat": "Jemand ist bedroht.",
+                "unhappySuffering": "Jemand ist ungl\u00fccklich oder leidet.",
+                "unusualIdeas": "Un\u00fcbliche Ideen oder Standpunkte werden offen diskutiert.",
+                "verbalFluency": "Es gibt M\u00f6glichkeiten, Sprachgewandtheit zum Ausdruck zu bringen (zum Beispiel: eine Debatte, ein Monolog, eine aktive Konversation).",
+                "workingHard": "Menschen arbeiten hart.",
+                "youFocus": "Sie stehen im Mittelpunkt der Aufmerksamkeit."
+            }
+        },
+        "sections": {
+            "1": {
+                "activity": "Aktivit\u00e4t:",
+                "categories": {
+                    "characteristic": "charakteristisch",
+                    "neutral": "neutral",
+                    "uncharacteristic": "uncharakteristisch"
+                },
+                "instructions": "Bitte beschreiben Sie nun die Situation, die Sie erlebt haben, detaillierter. 90 Elemente werden einzeln erscheinen. Bitte platzieren Sie jedes Element in einem der drei K\u00e4sten. Verwenden Sie den Kasten \"charakteristisch\" auf der rechten Seiten f\u00fcr Elemente, die die Situation akkurat beschreiben; verweden Sie den Kasten \"uncharakteristisch\" auf der linken Seite f\u00fcr Elemente, die die Situation sehr wenig beschreiben. Verwenden Sie den Kasten \"neutral\" f\u00fcr Elemente, die irrelevant sind, unklar oder \u00fcber welche Sie sich unsicher sind. Wenn Sie dies beendet haben, dr\u00fccken Sie \"weiter\".",
+                "itemsLeft": "Elemente \u00fcbrig",
+                "location": "Ort:",
+                "othersPresent": "Andere anwesend:"
+            },
+            "2": {
+                "categories": {
+                    "extremelyChar": "Sehr charakteristisch",
+                    "extremelyUnchar": "Sehr uncharakteristisch",
+                    "fairlyChar": "Recht charakteristisch",
+                    "fairlyUnchar": "Recht uncharakteristisch",
+                    "neutral": "Weder charakteristisch noch uncharakteristisch",
+                    "quiteChar": "Ziemlich charakteristisch",
+                    "quiteUnchar": "Ziemlich uncharakteristisch",
+                    "somewhatChar": "Ein wenig charakteristisch",
+                    "somewhatUnchar": "Ein wenig uncharakteristisch"
+                },
+                "instructions": "Bitte beschreiben Sie die Situation nun pr\u00e4ziser. Bitte platzieren Sie die Elemente aus den drei K\u00e4sten in die untenstehenden neun K\u00e4sten. Sie k\u00f6nnen die Elemente von einem Kasten in den anderen Kasten verschieben. Wenn Sie allerdings zu viele Elemente in einem Kasten haben, wird die \u00dcberschrift dieses Kastens rot angezeigt. Die \u00dcberschrift wird gr\u00fcn werden, wenn Sie die richtige Anzahl an Elementen in dem Kasten haben."
+            }
+        }
+    },
+    "survey": {
+        "sections": {
+            "1": {
+                "instructions": "Willkommen! Wir sind daran interessiert, wie Menschen Situationen wahrnehmen und wie sie sich in diesen Situationen verhalten. Sie werden gebeten, eine Situation zu beschreiben, die Sie k\u00fcrzlich erlebt haben, und was Sie in dieser Situation getan haben. Auch werden Sie Fragen zu Ihren Einstellungen und Werten erhalten. Basierend auf diesen Antworten werden Sie am Ende der Studie individualisierte Angaben zu Ihrer Pers\u00f6nlichkeit erhalten, von denen wir hoffen, dass Sie sie interessant finden. Um zu beginnen, beantworten Sie bitte einige Fragen \u00fcber sich.",
+                "questions": {
+                    "1": {
+                        "label": "Alter"
+                    },
+                    "10": {
+                        "label": "Wenn ja, welcher Religion folgen Sie?"
+                    },
+                    "11": {
+                        "label": "Geburtsland"
+                    },
+                    "2": {
+                        "label": "Geschlecht",
+                        "options": {
+                            "female": "weiblich",
+                            "male": "m\u00e4nnlich",
+                            "na": "Ich m\u00f6chte die Frage lieber nicht beantworten",
+                            "other": "anderes"
+                        }
+                    },
+                    "3": {
+                        "label": "Welche Ethnizit\u00e4t haben Sie?"
+                    },
+                    "4": {
+                        "label": "Was war Ihre erste Sprache?"
+                    },
+                    "5": {
+                        "label": "Auf einer Skala von 1 bis 10, wo w\u00fcrden Sie die \u00f6konomische Position Ihrer Familie sehen?",
+                        "options": {
+                            "average": "Durchschnitt",
+                            "least": "Am wenigsten wohlhabend",
+                            "most": "Am wohlhabendsten"
+                        }
+                    },
+                    "6": {
+                        "label": "Geburtsstadt"
+                    },
+                    "7": {
+                        "label": "Heimatstadt",
+                        "options": {
+                            "remoteRural": "abgelegen l\u00e4ndlich",
+                            "rural": "l\u00e4ndlich",
+                            "suburban": "im st\u00e4dtischen Aussenbezirk",
+                            "urban": "st\u00e4dtisch"
+                        }
+                    },
+                    "8": {
+                        "label": "Auf einer Skale von 1 bis 10, wie religi\u00f6s sind Sie?",
+                        "options": {
+                            "highlyReligious": "Sehr religi\u00f6s",
+                            "notReligious": "Gar nicht religi\u00f6s",
+                            "preferNoAnswer": "Ich m\u00f6chte die Frage lieber nicht beantworten"
+                        }
+                    },
+                    "9": {
+                        "label": "Folgen Sie einer Religion?",
+                        "options": {
+                            "noLabel": "Nein",
+                            "preferNoAnswer": "Ich m\u00f6chte die Frage lieber nicht beantworten",
+                            "yesLabel": "Ja"
+                        }
+                    }
+                }
+            },
+            "2": {
+                "instructions": {
+                    "firstSection": "Bitte beschreiben Sie ein Erlebnis, das Sie gestern erlebt haben und das Sie gut erinnnern.",
+                    "secondSection": "Jedes Erlebnis, welches Sie gestern hatten, eignet sich daf\u00fcr; Es ist allein entscheidend, dass Sie dieses gut erinnern. Bitte beschreiben Sie insbesondere was Sie gemacht haben, wo Sie waren und wer anwesend war.",
+                    "thirdSection": "Bitte geben Sie Ihre Antworten in die untenstehenden K\u00e4sten ein."
+                },
+                "questions": {
+                    "11": {
+                        "characterCount": "0 von 75 Zeichen verwendet",
+                        "label": "Was haben Sie zu diesem Zeitpunkt gemacht?"
+                    },
+                    "12": {
+                        "characterCount": "0 von 75 Zeichen verwendet",
+                        "label": "Wo waren Sie?"
+                    },
+                    "13": {
+                        "characterCount": "0 von 75 Zeichen verwendet",
+                        "label": "Wer war noch anwesend? (Wenn Sie alleine waren, schreiben Sie bitte \"alleine\")."
+                    },
+                    "14": {
+                        "label": "Zu welcher Zeit hat das Erlebnis ungef\u00e4hr begonnen?"
+                    }
+                }
+            }
+        }
+    },
+    "thankyou": {
+        "exitButton": "Die Studie beenden",
+        "instructions": "Sie k\u00f6nnen die Studie nun verlassen oder fortfahren, um Informationen zu Ihrer Pers\u00f6nlichkeit zu erhalten. Diese Auswertung basiert auf der Befragung, die Sie soeben beendet haben.",
+        "personalityFeedbackButton": "Feedback zur Pers\u00f6nlichkeit erhalten.",
+        "title": "Vielen Dank!"
+    }
+};

--- a/config/environment.js
+++ b/config/environment.js
@@ -77,18 +77,18 @@ module.exports = function(environment) {
 
   ENV.featureFlags = {
     // Whether to load existing expData into the exp-frames
-    loadData: false,
+    loadData: true,
 
     // Whether to validate survey forms
-    validate: false,
+    validate: true,
 
     // Whether to redirect users who have already taken the study to an error page
     // Set to false to test study multiple times with the same account
-    showStudyCompletedPage: false,
+    showStudyCompletedPage: true,
 
     // Whether to take the participant to the last page they were on
     // when they exited the study. If false, start from the beginning.
-    continueSession: false
+    continueSession: true
   };
 
   return ENV;

--- a/config/environment.js
+++ b/config/environment.js
@@ -77,18 +77,18 @@ module.exports = function(environment) {
 
   ENV.featureFlags = {
     // Whether to load existing expData into the exp-frames
-    loadData: true,
+    loadData: false,
 
     // Whether to validate survey forms
-    validate: true,
+    validate: false,
 
     // Whether to redirect users who have already taken the study to an error page
     // Set to false to test study multiple times with the same account
-    showStudyCompletedPage: true,
+    showStudyCompletedPage: false,
 
     // Whether to take the participant to the last page they were on
     // when they exited the study. If false, start from the beginning.
-    continueSession: true
+    continueSession: false
   };
 
   return ENV;

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,5 +1,26 @@
 # Usage
 
+## Adding/ updating consent form text
+To update consent form text, see [`scripts/consent_form_json.py`](https://github.com/CenterForOpenScience/isp/blob/develop/scripts/consent_form_json.py)
+
+
+## Adding/updating translations
 To update the translations for a given locale, see [`scripts/format_translations.py`](https://github.com/CenterForOpenScience/isp/blob/develop/scripts/format_translations.py)
 
-To update consent form text, see [`scripts/consent_form_json.py`](https://github.com/CenterForOpenScience/isp/blob/develop/scripts/consent_form_json.py)
+
+1. Download the CSV file for the translation. It should be in a 2-column format, where column 1 is the JSON key name, and column 2 is the translated text
+
+```
+Key,German Translation
+flag.chooseLanguage,Bitte wählen Sie eine Sprache
+```
+
+2. Run the format_translations script
+
+3. If a locale does not yet exist, run `ember generate locale <code>`, using either a two or four language country 
+code (like `en` or `en-US`) that corresponds to items from the [language picker](https://github.com/abought/isp/blob/a5159baae38756990e5f59c6be1b0bc9e64e25be/app/components/language-picker/countries.js#L636)
+
+4. Review the error messages from the format_translations script in the console, appropriate. 
+Paste the generated JSON into the appropriate `translations.js` file.
+ 
+ 5. Verify that the locale displays appropriately, including any RTL settings required.

--- a/scripts/consent_form_json.py
+++ b/scripts/consent_form_json.py
@@ -7,13 +7,17 @@
     1. Obtain client_secret.json file:
        a. Go to https://console.developers.google.com/
        b. Create a project for ISP
-       c. Under the credentials tab, click Create Credentials --> OAuth client ID, select "Web application"
+       c. Under the credentials tab, click Create Credentials --> OAuth client ID, select "Other"
           as application type and click "Create"
        d. Find the newly created credentials under "OAuth 2.0 client IDs" and download as json
        e. Rename json file to "client_secret.json"
     2. In the scripts directory, create a 'credentials' folder and add the client_secret.json file
     3. Run the script: `python -m scripts.consent_form_json`
     4. Add the json from the generated file (consent.json) to isp/app/components/isp-consent-form/consentText.js
+
+    The first time you run this script, you may get a message saying that you need to authorize specific APIs for use
+    with this project. The message will provide instructions needed to complete this process; wait several minutes
+    and then try running again.
 
     Modifies: https://developers.google.com/drive/v3/web/quickstart/python """
 
@@ -40,8 +44,9 @@ APPLICATION_NAME = 'International Situations Project'
 
 # Downloaded csv files with each site's consent form
 files_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'consent_forms')
-FILES = os.listdir(files_path)
-FOLDER_ID = "0Bxbak_ZCyxJ5Wl85ZFNERjlWMU0"
+
+## This may be a different folder for every translation
+FOLDER_ID = "0By5YcDUx8UZsdUxQRURIZlg5SjA"
 
 
 def get_credentials():
@@ -78,19 +83,19 @@ def main():
     download_files(data['files'], service)
 
     # convert csv files to a single json file
-    content = dict()
-    for filename in FILES:
+    content = {}
+    for filename in os.listdir(files_path):
         site_id = filename.split('.')[0]
         content[site_id] = format_consent_form('consent_forms/' + filename)
-    f = open('consent.json', 'w')
-    f.write(json.dumps(content, indent=4, sort_keys=True))
+    with open('consent.json', 'w') as f:
+        json.dump(content, f, indent=4, sort_keys=True)
 
 
 def download_files(files, service):
     for f in files:
         file_id = f['id']
         request = service.files().export_media(fileId=file_id, mimeType='text/csv').execute()
-        fn = '%s.csv' % os.path.splitext('consent_forms/' + files[0]['name'].replace(' ', '_'))[0]
+        fn = '%s.csv' % os.path.splitext('consent_forms/' + f['name'].replace(' ', '_'))[0]
         if request:
             with open(fn, 'wb') as csvfile:
                 csvfile.write(request)

--- a/scripts/format_translations.py
+++ b/scripts/format_translations.py
@@ -5,7 +5,7 @@
     1. Obtain access to translation spreadsheet for the desired locale from client
     2. Download the spreadsheet as a csv file and add it to the isp/scripts directory
     3. Run the script, passing in the csv file's name:
-       e.g. `python format_translations --filename en-us.csv --validate`
+       e.g. `python format_translations.py --filename en-us.csv --validate`
     4. Copy & paste the json from the generated file to the translations.js file in isp/app/locales/<locale>/
        See isp/app/locales/en/translations.js as an example.
        Note: If the locale folder does not exist, run 'ember generate locale <locale> in the isp/app directory.
@@ -13,12 +13,7 @@
 
 This assumes a CSV file of the following format:
        Column 1 = JSON key
-       Column 2 = English text
-       Column 3 = Translation
-       Column 4 = Back translation
-       Column 5 = Discrepancies
-       Column 6 = Final translation
-       Column 7 = Comments
+       Column 2 = Translated text
 """
 import argparse
 import collections
@@ -179,8 +174,6 @@ def parse_args():
     parser.add_argument('-f', '--filename', dest='filename', required=True)
     parser.add_argument('-o', '--out', dest='out',
                         help='The output filename; defaults to <filename>.json')
-    parser.add_argument('--test', dest='use_column', default=5, action='store_const', const=1,
-                        help='Testing mode (always writes the english text, useful on files where no translation has been provided yet)')
     parser.add_argument('-v', '--validate', dest='validate', action='store_true')
     return parser.parse_args()
 
@@ -202,7 +195,7 @@ def main():
         reader = csv.reader(csvfile)
         for row in reader:
             keys = row[0].split('.')
-            merge(data, format_dict(keys, row[args.use_column].strip(" ")))
+            merge(data, format_dict(keys, row[1].strip(" ")))
     with open(out_fn, 'w') as f:
         data.update(numbers)
         json.dump(data, f, indent=4, sort_keys=True)


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-324

## Purpose
Add German translation (de) to ISP

## Summary of changes
- Add german translation
- Add consent text for german-speaking sites
- Fix the script that downloads consent forms
- Update misc doc and formatting code based on first translation in the wild

## Testing notes

## What to test
- Pick German as your language. Move through the study and confirm that all text is translated.
- Use German as your language, but with an English-speaking site ID. Confirm that the consent form is in english but the study is in German.
  - ...and vice versa
- Verify the correct consent form text appears for one account created for each site ID

## Where to test
This affects the following choices in the language picker:
- Austria (deutsch)
- Germany (deutsch)
- Switzerland (deutsch)

All three language codes will use the same underlying `de` translation.

The consent text is controlled separately from the translation, and is controlled by the study ID. The following individual consent forms should be verified by creating accounts for the appropriate study IDs (study IDs are case sensitive)
- BASE.CH
- BERL.DE
- GOTT.DE
- GRAZ.AU
- INNS.AU
- ZURI.CH