### PR TITLE
Fix race condition that prevented session from being marked as complete

### DIFF
--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -12,14 +12,15 @@ export default ExpPlayer.extend({
             // Mark the current user account as having completed a session, then, also update the session model
             // If this fails to save the account due to normal network issues, it will still update the session but
             // swallow the error
+            this.get('session').set('completed', true);
+
             return this.get('currentUser').getCurrentUser().then(([account]) => {
                 // Deal with `extra` field sometimes being undefined
                 let dest = account.get('extra') || {};
                 dest['hasCompletedStudy'] = true;
                 account.set('extra', dest);
                 return account.save();
-            }).catch( e => console.log('Could not mark account as having completed study:', e)
-            ).finally(() => this._super(...arguments));
-        },
+            }).catch( e => console.error('Could not mark account as having completed study:', e));
+        }
     }
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-330

## Purpose
Ember actions are fire and forget (unless using closure actions + return values).

So when the frame next/save action happened, it had the effect of saving the frame payload before the flag got set. 

## Summary of changes
This changes the order of operations: it marks the session as complete, then saves the account, instead of tying the two saves together.

This increases the risk of data / state inconsistency slightly (between session and account models) but it's the best option shy of large internal refactorings.

## Testing notes
Try to complete the study. When done:
1. The completed study should have `data.attributes.completed` = true in the payload sent to the server
2. A completed record for that participant should show up in the experimenter "participants" page
3. The participant should be listed correctly in the ISP `/site-admin` route.

You can complete a study faster in local development using the feature flags in `config/environment.js` to run off the steps that slow you down.

[#LEI-330]