### PR TITLE
Feature/i18n improvements [LEI-327]

### DIFF
--- a/app/components/language-picker/countries.js
+++ b/app/components/language-picker/countries.js
@@ -296,7 +296,7 @@ export default [
         "languages": [
             {
                 "code": "lt-LT",
-                "name": "Lietuvos"
+                "name": "Latviešu"
             }
         ],
         "name": "Lithuania"

--- a/app/locales/de/translations.js
+++ b/app/locales/de/translations.js
@@ -967,7 +967,10 @@ export default {
                     "uncharacteristic": "uncharakteristisch"
                 },
                 "instructions": "Bitte beschreiben Sie nun die Situation, die Sie erlebt haben, detaillierter. 90 Elemente werden einzeln erscheinen. Bitte platzieren Sie jedes Element in einem der drei K\u00e4sten. Verwenden Sie den Kasten \"charakteristisch\" auf der rechten Seiten f\u00fcr Elemente, die die Situation akkurat beschreiben; verwenden Sie den Kasten \"uncharakteristisch\" auf der linken Seite f\u00fcr Elemente, die die Situation sehr wenig beschreiben. Verwenden Sie den Kasten \"neutral\" f\u00fcr Elemente, die irrelevant sind, unklar oder \u00fcber welche Sie sich unsicher sind. Wenn Sie dies beendet haben, dr\u00fccken Sie \"weiter\".",
-                "itemsLeft": "Elemente \u00fcbrig",
+                "itemsLeft": {
+                    "one": "{{count}} Element \u00fcbrig",
+                    "other": "{{count}} Elemente \u00fcbrig"
+                },
                 "location": "Ort:",
                 "othersPresent": "Andere anwesend:"
             },

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -978,7 +978,10 @@ const translations = {
                     "uncharacteristic": "Uncharacteristic"
                 },
                 "instructions": "Now please describe the situation you experienced in more detail. 90 items will appear one at a time.  Place each item into one of three boxes.  Use the \u201cCharacteristic\u201d box on the right for items that accurately describe the situation; use the \u201cUncharacteristic\u201d box on the left for items that are undescriptive of the situation, and use the \u201cNeutral\u201d box for items that are irrelevant, unclear, or about which you are uncertain.  When you are finished, press \u201cContinue.\u201d",
-                "itemsLeft": "items left",
+                "itemsLeft": {
+                    "one": "{{count}} item left",
+                    "other": "{{count}} items left"
+                },
                 "location": "Location:",
                 "othersPresent": "Others present:"
             },


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-327

## Purpose
* Lithuania language is incorrect
* Need to account for internationalized word order for number of items left on card sort component

## Summary of changes
* Lithuania fix in language picker component: ![screen shot 2016-12-15 at 14 04 47](https://cloud.githubusercontent.com/assets/3374510/21238116/bfebaa66-c2cf-11e6-8707-54752f6de600.png)
* Updates to translation files and exp-card-sort component (PR forthcoming)
![screen shot 2016-12-15 at 12 18 39](https://cloud.githubusercontent.com/assets/3374510/21238237/491be3a0-c2d0-11e6-8edf-a7eabb7c7b8d.png)
![screen shot 2016-12-15 at 13 52 54](https://cloud.githubusercontent.com/assets/3374510/21238236/491afaee-c2d0-11e6-95cb-b0353ba5400e.png)

## Notes for reviewers
See [Ember-i18n Pluralization](https://github.com/jamesarosen/ember-i18n/wiki/Doc:-Pluralization)

## Testing notes
For the card sort When the number of items left goes to 1, it should say 'item' instead of 'items'