### PR TITLE
[rfr] Don't modify the session record just to show "you already completed" page

### DIFF
--- a/app/controllers/participate/login.js
+++ b/app/controllers/participate/login.js
@@ -30,6 +30,7 @@ export default Ember.Controller.extend({
             var surveyController = Ember.getOwner(this).lookup('controller:participate');
             surveyController.set('studyId', attrs.password);
             surveyController.set('participantId', attrs.username);
+            this.set('authenticating', false);
             this.transitionToRoute('participate.survey.consent');
           })
           .catch((e) => {

--- a/app/routes/participate/survey.js
+++ b/app/routes/participate/survey.js
@@ -4,85 +4,86 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import config from 'ember-get-config';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
-  _experiment: null,
-  _session: null,
-  store: Ember.inject.service(),
-  currentUser: Ember.inject.service(),
-  i18n: Ember.inject.service(),
+    _experiment: null,
+    _session: null,
+    store: Ember.inject.service(),
+    currentUser: Ember.inject.service(),
+    i18n: Ember.inject.service(),
 
-  _getExperiment() {
-    return this.store.find('experiment', config.studyId);
-  },
-  _getSession(params, experiment) { // jshint ignore: line
-    return this.get('currentUser').getCurrentUser().then(([account, profile]) => {
-      return account.pastSessionsFor(experiment, profile).then((pastSessions) => {
-        if (pastSessions.get('length') === 0) {
-          return this.store.createRecord(experiment.get('sessionCollectionId'), {
-            experimentId: experiment.id,
-            profileId: account.get('username') + '.' + account.get('username'),
-            completed: false,
-            feedback: '',
-            hasReadFeedback: '',
-            expData: {},
-            sequence: []
-          });
-        }
-        return pastSessions.objectAt(0);
-      });
-    });
-  },
-  model(params) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      this._getExperiment(params).then((experiment) => {
-        this._getSession(params, experiment).then((session) => {
-          if (session.get('completed') && config.featureFlags.showStudyCompletedPage) {
-            this.transitionTo('participate.complete');
-          }
-          this.set('_experiment', experiment);
-          session.set('experimentVersion', '');
-
-          if (!session.get('extra')) {
-              session.set('extra', {});
-          }
-
-          session.set('extra.locale', this.get('i18n.locale')); // The user's locale
-          session.set('extra.studyId', this.controllerFor('participate').get('studyId')); // The siteID for the location where the study was taken
-          session.save().then(() => {
-            this.set('_session', session);
-            resolve(session);
-          });
+    _getExperiment() {
+        return this.store.find('experiment', config.studyId);
+    },
+    _getSession(params, experiment) { // jshint ignore: line
+        return this.get('currentUser').getCurrentUser().then(([account, profile]) => {
+            return account.pastSessionsFor(experiment, profile).then((pastSessions) => {
+                if (pastSessions.get('length') === 0) {
+                    return this.store.createRecord(experiment.get('sessionCollectionId'), {
+                        experimentId: experiment.id,
+                        profileId: account.get('username') + '.' + account.get('username'),
+                        completed: false,
+                        feedback: '',
+                        hasReadFeedback: '',
+                        expData: {},
+                        sequence: []
+                    });
+                }
+                return pastSessions.objectAt(0);
+            });
         });
-      }).catch(reject);
-    });
-  },
-  beforeModel(transition) {
-    this._super(transition);
+    },
+    model(params) {
+        return new Ember.RSVP.Promise((resolve, reject) => {
+            this._getExperiment(params).then((experiment) => {
+                this._getSession(params, experiment).then((session) => {
+                    if (session.get('completed') && config.featureFlags.showStudyCompletedPage) {
+                        this.transitionTo('participate.complete');
+                    }
+                    this.set('_experiment', experiment);
+                    session.set('experimentVersion', '');
 
-    var locale;
-    try {
-      locale = this.controllerFor('participate').get('locale');
-    } catch (e) {}
-    if (!locale) {
-      this.transitionTo('participate.login');
-    } else {
-      this.transitionTo('participate.survey.consent');
+                    if (!session.get('extra')) {
+                        session.set('extra', {});
+                    }
+
+                    session.set('extra.locale', this.get('i18n.locale')); // The user's locale
+                    session.set('extra.studyId', this.controllerFor('participate').get('studyId')); // The siteID for the location where the study was taken
+                    session.save().then(() => {
+                        this.set('_session', session);
+                        resolve(session);
+                    });
+                });
+            }).catch(reject);
+        });
+    },
+    beforeModel(transition) {
+        this._super(transition);
+
+        var locale;
+        try {
+            locale = this.controllerFor('participate').get('locale');
+        } catch (e) {
+        }
+        if (!locale) {
+            this.transitionTo('participate.login');
+        } else {
+            this.transitionTo('participate.survey.consent');
+        }
+    },
+    activate () {
+        let session = this.get('_session');
+        // Include session ID in any raven reports that occur during the experiment
+        this.get('raven').callRaven('setExtraContext', {
+            sessionID: session.id,
+            participantID: this.controllerFor('participate').get('participantId'),
+            locale: this.controllerFor('participate').get('locale')
+        });
+        return this._super(...arguments);
+    },
+    setupController(controller, session) {
+        this._super(controller, session);
+
+        controller.set('experiment', this.get('_experiment'));
+        controller.set('session', session);
+        controller.set('pastSessions', []);
     }
-  },
-  activate () {
-    let session = this.get('_session');
-    // Include session ID in any raven reports that occur during the experiment
-    this.get('raven').callRaven('setExtraContext', {
-      sessionID: session.id,
-      participantID:this.controllerFor('participate').get('participantId'),
-      locale: this.controllerFor('participate').get('locale')
-    });
-    return this._super(...arguments);
-  },
-  setupController(controller, session) {
-    this._super(controller, session);
-
-    controller.set('experiment', this.get('_experiment'));
-    controller.set('session', session);
-    controller.set('pastSessions', []);
-  }
 });

--- a/app/routes/participate/survey.js
+++ b/app/routes/participate/survey.js
@@ -14,22 +14,25 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
         return this.store.find('experiment', config.studyId);
     },
     _getSession(params, experiment) { // jshint ignore: line
-        return this.get('currentUser').getCurrentUser().then(([account, profile]) => {
-            return account.pastSessionsFor(experiment, profile).then((pastSessions) => {
-                if (pastSessions.get('length') === 0) {
-                    return this.store.createRecord(experiment.get('sessionCollectionId'), {
-                        experimentId: experiment.id,
-                        profileId: account.get('username') + '.' + account.get('username'),
-                        completed: false,
-                        feedback: '',
-                        hasReadFeedback: '',
-                        expData: {},
-                        sequence: []
-                    });
+        let username;
+        return this.get('currentUser').getCurrentUser()
+            .then(([account, profile]) => {
+                username = account.get('username');
+                return account.pastSessionsFor(experiment, profile);
+            }).then((pastSessions) => {
+                if (pastSessions.get('length') !== 0) {
+                    return pastSessions.objectAt(0);
                 }
-                return pastSessions.objectAt(0);
+                return this.store.createRecord(experiment.get('sessionCollectionId'), {
+                    experimentId: experiment.id,
+                    profileId: username + '.' + username,
+                    completed: false,
+                    feedback: '',
+                    hasReadFeedback: '',
+                    expData: {},
+                    sequence: []
+                });
             });
-        });
     },
     model(params) {
         return new Ember.RSVP.Promise((resolve, reject) => {


### PR DESCRIPTION
https://trello.com/c/u3171bwO/18-survey-results-completion-date-changed-to-current-date

## Purpose
When a user has already completed the study and tries to log back in, they should not change the date last logged in.

Also, refactor a bit to simplify the promise in an attempt to reduce how often transition aborted errors are getting logged to sentry. (and simplify logic for future debugging of barrett's mysterious amazing multiple sessions per user)

## Summary of changes
- Refactor promise pyramids
- Use aftermodel hook for handling transition changes
- Fix possible async race condition that was causing models to change and save when they shouldn't

## Testing notes
### Check that this resolves spurious transition aborted errors
- [x] Go to the homepage, and open the JS error console in your browser. Then log in as a user who has already completed the study. 
  - Before the fix: As you are drawn to the desired page, you would see a `transition aborted` error in the console: `Raven about to send: Object { project: "55", logger: "javascript", platform: "javascript", request: Object, message: "TransitionAborted", extra: Object, breadcrumbs: Object, user: Object, release: "0.0.0+db6c9fb6", event_id: "aab38c2c85bc455c86d7dd4d68c91e95" }`
  - After the fix: this error should no longer occur.

### Check that users get to the right page when they should
This PR depends on certain settings that are not available in “testing mode”. If you are running locally, set all feature flags in config/environment.js to true., so that the application behaves as intended in production.

- [x] When participating in a survey: if the user has participated previously, fetch the previous survey result and behave as appropriate.

  - [x] Try to log in using an account that has previously completed the survey. You should see the “you have already completed the study” page. If you check experiment results page and look at that session record, the date of completion will not have changed just because you logged in.
  - [x] Try to log in as an account that has only gotten as far as page 2 of the survey (second screen of questions after consent form). You should start the survey where you left off, and if you hit the previous button, answers should be filled in for that previous page. If you continue the survey and finish, the date of completion will show the current date.

  - [x] Create a fresh account. You should be able to proceed through the survey as intended. Then refresh the page. Confirm you are yanked back to the home page, log in again, and see if the site behaves as expected for a repeat visitor.

It should not be possible to create more than one record for the same user.

### Results are unchanged if user already completed
If you go to the completed study page, then the "finished date" will not change in the summary of results. `ucr_1` is a good account to try this with.
https://staging-experimenter.osf.io/experiments/581202be3de08a003a2aca34/results

### Known issues
There is a known JamDB issue where users with all-numeric ids can bypass the "only do experiment once" rule. Try these steps with a username that contains letters or non-numeric characters.