### PR TITLE
Feature/trim translations

### DIFF
--- a/app/components/language-picker/component.js
+++ b/app/components/language-picker/component.js
@@ -1,40 +1,59 @@
 import Ember from 'ember';
-
+import config from 'ember-get-config';
 import countries from './countries';
-
 
 export default Ember.Component.extend({
     i18n: Ember.inject.service(),
     countries: countries,
-    languages: Ember.computed('countries', function() {
-      var langs = [];
-      this.get('countries').forEach((country) => {
-        country.languages.forEach((lang) => {
-          langs.push({
-            countryCode: country.code,
-            countryName: country.name,
-            name: lang.name,
-            code: lang.code
-          });
+    languages: Ember.computed('countries', 'i18n.locales', function () {
+        const isProduction = config.environment === 'production';
+        const locales = this.get('i18n.locales').toArray();
+        const countries = this.get('countries');
+        const languages = [];
+
+        for (const locale of locales) {
+            if (isProduction && locale === 'test') {
+                continue;
+            }
+
+            const rgx = new RegExp(`^${locale}`);
+
+            for (const country of countries) {
+                for (const language of country.languages) {
+                    if (rgx.test(language.code)) {
+                        languages.push({
+                            countryCode: country.code,
+                            countryName: country.name,
+                            name: language.name,
+                            code: language.code
+                        });
+
+                        break;
+                    }
+                }
+            }
+        }
+
+        languages.sort((a, b) => {
+            if (a.countryName > b.countryName) {
+                return 1;
+            }
+
+            if (a.countryName < b.countryName) {
+                return -1;
+            }
+
+            return 0;
         });
-      });
-      langs.sort(function(a, b) {
-        if (a.countryName > b.countryName) {
-          return 1;
-        }
-        if (a.countryName < b.countryName) {
-          return -1;
-        }
-        return 0;
-      });
-      return langs;
+
+        return languages;
     }),
     onPick: null,
     country: null,
     actions: {
-      pickLanguage(language, code) {
-        this.get('onPick')(language, code);
-        this.set('i18n.locale', code);
-      }
+        pickLanguage(language, code) {
+            this.get('onPick')(language, code);
+            this.set('i18n.locale', code);
+        }
     }
 });

--- a/app/components/language-picker/component.js
+++ b/app/components/language-picker/component.js
@@ -6,13 +6,13 @@ export default Ember.Component.extend({
     i18n: Ember.inject.service(),
     countries: countries,
     languages: Ember.computed('countries', 'i18n.locales', function () {
-        const isProduction = config.environment === 'production';
+        const {excludeTestLocale} = config.featureFlags;
         const locales = this.get('i18n.locales').toArray();
         const countries = this.get('countries');
         const languages = [];
 
         for (const locale of locales) {
-            if (isProduction && locale === 'test') {
+            if (excludeTestLocale && locale === 'test') {
                 continue;
             }
 

--- a/app/components/language-picker/component.js
+++ b/app/components/language-picker/component.js
@@ -16,11 +16,9 @@ export default Ember.Component.extend({
                 continue;
             }
 
-            const rgx = new RegExp(`^${locale}`);
-
             for (const country of countries) {
                 for (const language of country.languages) {
-                    if (rgx.test(language.code)) {
+                    if (language.code.startsWith(locale)) {
                         languages.push({
                             countryCode: country.code,
                             countryName: country.name,

--- a/config/environment.js
+++ b/config/environment.js
@@ -67,7 +67,10 @@ module.exports = function(environment) {
 
     // Whether to take the participant to the last page they were on
     // when they exited the study. If false, start from the beginning.
-    continueSession: true
+    continueSession: true,
+
+    // Whether to include the test locale or not
+    excludeTestLocale: environment === 'production',
   };
 
   return ENV;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,7 +6,12 @@ module.exports = function(defaults) {
     var app = new EmberApp(defaults, {
         'ember-bootstrap': {
             importBootstrapFont: false
-        }
+        },
+
+        babel: {
+            optional: ['es6.spec.symbols'],
+            includePolyfill: true
+        },
     });
 
     // Use `app.import` to add additional libraries to the generated

--- a/tests/integration/components/language-picker/component-test.js
+++ b/tests/integration/components/language-picker/component-test.js
@@ -1,31 +1,34 @@
-import { moduleForComponent, test } from 'ember-qunit';
+import {moduleForComponent, test} from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import Ember from 'ember';
 
 
 const localeStub = Ember.Service.extend({
-  locale: null
+    locale: null,
+    locales: [
+        'en'
+    ]
 });
 
 moduleForComponent('language-picker', 'Integration | Component | language picker', {
-  integration: true,
+    integration: true,
 
-  beforeEach: function() {
-    this.register('service:i18n', localeStub);
-    this.inject.service('i18n', { as: 'i18n' });
-  }
+    beforeEach: function () {
+        this.register('service:i18n', localeStub);
+        this.inject.service('i18n', {as: 'i18n'});
+    }
 });
 
-test('it sets the locale', function(assert) {
+test('it sets the locale', function (assert) {
 
-  this.set('selectLanguage', (language, code) => {
-    assert.deepEqual(language, 'English');
-    assert.deepEqual(code, 'en-US');
-  });
+    this.set('selectLanguage', (language, code) => {
+        assert.deepEqual(language, 'English');
+        assert.deepEqual(code, 'en-US');
+    });
 
-  this.render(hbs`{{language-picker onPick=(action selectLanguage)}}`);
+    this.render(hbs`{{language-picker onPick=(action selectLanguage)}}`);
 
-  this.$('.flag-icon-us').first().parent().click();
-  assert.equal(this.get('i18n.locale'), 'en-US');
-  assert.expect(3);
+    this.$('.flag-icon-us').first().parent().click();
+    assert.equal(this.get('i18n.locale'), 'en-US');
+    assert.expect(3);
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-323

## Purpose
Removes countries that do not have a translation in the language picker

## Summary of changes
Relies on ember-i18n's locale listing to figure out which countries/languages to display. If on production, doesn't show x-pseudo option

### Before
![screen shot 2017-01-06 at 12 00 38](https://cloud.githubusercontent.com/assets/3374510/21725786/d758b862-d407-11e6-8bc0-24053cb8c80d.png)

### After
![screen shot 2017-01-06 at 11 59 38](https://cloud.githubusercontent.com/assets/3374510/21725794/df4be21a-d407-11e6-80db-70e31eb82b7c.png)

## Testing notes
It should only display the available languages
