### PR TITLE
[hold][WIP] Suppress questions in sensitive experiment sites

### DIFF
--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 import ExpPlayer from 'exp-player/components/exp-player/component';
 
-import config from 'ember-get-config';
-
 export default ExpPlayer.extend({
     currentUser: Ember.inject.service(),
     i18n: Ember.inject.service(),
@@ -21,12 +19,7 @@ export default ExpPlayer.extend({
         return this.get('isRTL') ? 'rtl' : 'ltr';
     }),
 
-    isSensitive: Ember.computed('currentUser.studyID', function() {
-        // Track whether the player contains sensitive content
-        // TODO: get arabic site names
-        const locale = this.get('currentUser.studyID');
-        return config.sensitiveStudies.includes(locale);
-    }),
+    isSensitive: Ember.computed.alias('currentUser.isSensitive'),
 
     // Additional configuration required for ISP-specific use case
     extra: Ember.computed('isRTL', function() {

--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -1,6 +1,8 @@
 import Ember from 'ember';
 import ExpPlayer from 'exp-player/components/exp-player/component';
 
+import config from 'ember-get-config';
+
 export default ExpPlayer.extend({
     currentUser: Ember.inject.service(),
     i18n: Ember.inject.service(),
@@ -19,13 +21,24 @@ export default ExpPlayer.extend({
         return this.get('isRTL') ? 'rtl' : 'ltr';
     }),
 
+    isSensitive: Ember.computed('currentUser.studyID', function() {
+        // Track whether the player contains sensitive content
+        // TODO: get arabic site names
+        const locale = this.get('currentUser.studyID');
+        return config.sensitiveStudies.includes(locale);
+    }),
+
     // Additional configuration required for ISP-specific use case
     extra: Ember.computed('isRTL', function() {
-        return { isRTL: this.get('isRTL') };
+        return {
+            isRTL: this.get('isRTL'),
+            isSensitive: this.get('isSensitive')
+        };
     }),
     init() {
         // Services are lazily evaluated; make sure we can observe locale
         this.get('i18n');
+        this.get('currentUser');
         return this._super(...arguments);
     },
 

--- a/app/controllers/participate/login.js
+++ b/app/controllers/participate/login.js
@@ -3,9 +3,11 @@ import ENV from 'isp/config/environment';
 
 
 export default Ember.Controller.extend({
-  session: Ember.inject.service('session'),
+  currentUser: Ember.inject.service(),
+  session: Ember.inject.service(),
   i18n: Ember.inject.service(),
   raven: Ember.inject.service(),
+
   studyId: null,
   participantId: null,
   namespace: ENV.JAMDB.namespace,
@@ -28,7 +30,9 @@ export default Ember.Controller.extend({
           .authenticate('authenticator:jam-jwt', attrs)
           .then(() => {
             var surveyController = Ember.getOwner(this).lookup('controller:participate');
+            // TODO: Deprecate use of controller for shared state
             surveyController.set('studyId', attrs.password);
+            this.get('currentUser').set('studyID', attrs.password);
             surveyController.set('participantId', attrs.username);
             this.set('authenticating', false);
             this.transitionToRoute('participate.survey.consent');

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -1,0 +1,9 @@
+import CurrentUserService from 'exp-models/services/current-user';
+
+export default CurrentUserService.extend({
+    /**
+     * The studyID associated with the current user
+     * @property studyID
+     */
+    studyID: null,
+});

--- a/app/services/current-user.js
+++ b/app/services/current-user.js
@@ -1,3 +1,7 @@
+import Ember from 'ember';
+
+import config from 'ember-get-config';
+
 import CurrentUserService from 'exp-models/services/current-user';
 
 export default CurrentUserService.extend({
@@ -6,4 +10,11 @@ export default CurrentUserService.extend({
      * @property studyID
      */
     studyID: null,
+
+    isSensitive: Ember.computed('studyID', function() {
+        // Track whether the player contains sensitive content
+        // TODO: get arabic site names
+        const site = this.get('studyID');
+        return config.sensitiveStudies.includes(site);
+    }),
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -54,6 +54,9 @@ module.exports = function(environment) {
 
   ENV.studyId = process.env.EXPERIMENT_ID;
 
+  // List of study site location IDs that may be subject to sensitive content restrictions
+  ENV.sensitiveStudies = ['DUMMY1.DUM'];
+
   ENV.featureFlags = {
     // Whether to load existing expData into the exp-frames
     loadData: true,
@@ -70,7 +73,7 @@ module.exports = function(environment) {
     continueSession: true,
 
     // Whether to include the test locale or not
-    excludeTestLocale: environment === 'production',
+    excludeTestLocale: true,
   };
 
   return ENV;


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-344

⚠️ Hold until an arabic translation is ready. This will need very thorough and careful testing to be considered for release.

## TODO
- [ ] Hold this PR until arabic translation is available for final verification.
- [ ] In addition to display logic control, also split the locale into a "safe" subtag, such that users in sensitive locales are using a translation that altogether excludes the sensitive text (fallback to safety- multiple layers)
  - [ ] Modify the login page: before letting user in, check that the study ID is in a safe list, and only then set the "general audiences" locale subtag (otherwise fall back to the default unsafe/filtered locale). If user language + site combo not on the approved list, sensitive questions should be excluded.

## Purpose
Certain study sites need to show a restricted set of questions.

![screen shot 2017-01-10 at 5 45 40 pm](https://cloud.githubusercontent.com/assets/2957073/21828097/ac679b8e-d75c-11e6-880b-37aebd21d019.png)



## Summary of changes
- Start moving studyID over to a service for shared state (rather than straddling across parent controllers)
- Provide a mechanism for the player to identify whether the chosen study ID is a sensitive site
- Suppress certain study questions where appropriate

## Testing notes
See companion PR. Also:
- Verify that values are serialized into the correct field- even if using a "sensitive" study ID where some questions are missing. (eg if `ReligionScale4` is omitted, then answers above and below should go in fields `ReligionScale3` and `ReligionScale5`)
- Verify that when questions are omitted, user can proceed through study. (validation doesn't block on invisible questions)