### PR TITLE
Add S Africa to flag picker (uses english locale)

### DIFF
--- a/app/components/language-picker/countries.js
+++ b/app/components/language-picker/countries.js
@@ -506,6 +506,16 @@ export default [
         "name": "Slovenia"
     },
     {
+        "code": "ZA",
+        "languages": [
+            {
+                "code": "en-ZA",
+                "name": "South Africa"
+            }
+        ],
+        "name": "South Africa"
+    },
+    {
         "code": "KR",
         "languages": [
             {


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-349

## Purpose
Add S Africa flag to language picker modal. Uses english as a language.

## Summary of changes
![screen shot 2017-01-10 at 9 55 42 am](https://cloud.githubusercontent.com/assets/2957073/21810764/196da238-d71b-11e6-8b83-4e187915ea6e.png)


## Testing notes
- Correct flag should appear in language modal
- When locale selected, study will be in  english
