### PR TITLE
Further RTL support: misc pages and card sort UI

### DIFF
--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -5,18 +5,12 @@ export default ExpPlayer.extend({
     currentUser: Ember.inject.service(),
     i18n: Ember.inject.service(),
 
-   attributeBindings: ['rtlDir:dir'],
-
     // Show an early exit modal (return non-empty string), but only with browser default message- don't require translation of custom text.
     messageEarlyExitModal: ' ',
 
     isRTL: Ember.computed('i18n.locale', function() {
         // Define whether the selected locale is RTL. Make property available to all frames.
         return !!this.get('i18n._locale.rtl');
-    }),
-
-    rtlDir: Ember.computed('isRTL', function() {
-        return this.get('isRTL') ? 'rtl' : 'ltr';
     }),
 
     // Additional configuration required for ISP-specific use case

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+    i18n: Ember.inject.service(),
+
+    rtlDir: Ember.computed('i18n.locale', function() {
+        // Define whether the selected locale is RTL.
+        return !!this.get('i18n._locale.rtl') ? 'rtl' : 'ltr';
+    })
+});

--- a/app/controllers/participate/survey/consent.js
+++ b/app/controllers/participate/survey/consent.js
@@ -1,16 +1,25 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-  session: null,
-  studyId: Ember.computed(function() {
-    return Ember.getOwner(this).lookup('controller:participate').get('studyId');
-  }),
-  actions: {
-    grantConsent(hasGrantedConsent) {
-      var session = this.get('session');
-      session.set('hasGrantedConsent', hasGrantedConsent);
-      session.save();
-      this.transitionToRoute('participate.survey');
+    i18n: Ember.inject.service(),
+
+    session: null,
+
+    studyId: Ember.computed(function () {
+        return Ember.getOwner(this).lookup('controller:participate').get('studyId');
+    }),
+
+    rtlDir: Ember.computed('i18n.locale', function() {
+        // Define whether the selected locale is RTL.
+        return !!this.get('i18n._locale.rtl') ? 'rtl' : 'ltr';
+    }),
+
+    actions: {
+        grantConsent(hasGrantedConsent) {
+            var session = this.get('session');
+            session.set('hasGrantedConsent', hasGrantedConsent);
+            session.save();
+            this.transitionToRoute('participate.survey');
+        }
     }
-  }
 });

--- a/app/controllers/participate/survey/consent.js
+++ b/app/controllers/participate/survey/consent.js
@@ -1,17 +1,11 @@
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
-    i18n: Ember.inject.service(),
 
     session: null,
 
     studyId: Ember.computed(function () {
         return Ember.getOwner(this).lookup('controller:participate').get('studyId');
-    }),
-
-    rtlDir: Ember.computed('i18n.locale', function() {
-        // Define whether the selected locale is RTL.
-        return !!this.get('i18n._locale.rtl') ? 'rtl' : 'ltr';
     }),
 
     actions: {

--- a/app/routes/participate/survey/consent.js
+++ b/app/routes/participate/survey/consent.js
@@ -5,8 +5,8 @@ import ENV from 'isp/config/environment';
 
 export default Ember.Route.extend(AuthenticatedRouteMixin, {
     setupController(controller, session) {
-      this._super(controller, session);
-      controller.set('session', session);
+        this._super(controller, session);
+        controller.set('session', session);
     },
     model() {
         var session = this.modelFor('participate.survey');

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,1 +1,3 @@
-{{outlet}}
+<div dir="{{rtlDir}}">
+    {{outlet}}
+</div>

--- a/app/templates/participate/survey/consent.hbs
+++ b/app/templates/participate/survey/consent.hbs
@@ -1,1 +1,3 @@
-{{isp-consent-form studyId=studyId grantConsent=(action 'grantConsent')}}
+<div dir={{rtlDir}}>
+    {{isp-consent-form studyId=studyId grantConsent=(action 'grantConsent')}}
+</div>

--- a/app/templates/participate/survey/consent.hbs
+++ b/app/templates/participate/survey/consent.hbs
@@ -1,3 +1,1 @@
-<div dir={{rtlDir}}>
-    {{isp-consent-form studyId=studyId grantConsent=(action 'grantConsent')}}
-</div>
+{{isp-consent-form studyId=studyId grantConsent=(action 'grantConsent')}}


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-350

Companion to: https://github.com/CenterForOpenScience/exp-addons/pull/218

## Purpose
Make all pages in the site (not just the survey) respect RTL settings.

## Summary of changes
1. Consent form, login screen, "survey completed", and "thank you/see results" pages should now all be right-aligned when a right-aligned locale (such as hebrew) is selected.

2. Card sort category labels should run the opposite direction they do in english (eg characeristic --> uncharacteristic ). A screenshot is attached; feel free to spot-check words with google translate if you don't speak hebrew.

## Testing notes
See previous PR ___ and add these rules to the pages listed above.

- [x] Verify rtl alignment of text on various pages
- [x] Verify placement of category labels for card sort form
- [x] Verify that cards sorted appear in the correct bins, eg data is saved in the right place in the CSV file output for that participant.
