### PR TITLE
Do not allow user to login to an unrecognized study ID

### DIFF
--- a/app/controllers/participate/login.js
+++ b/app/controllers/participate/login.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import ENV from 'isp/config/environment';
 
+import {siteNames} from '../../components/isp-consent-form/consentText';
 
 export default Ember.Controller.extend({
   session: Ember.inject.service('session'),
@@ -31,7 +32,17 @@ export default Ember.Controller.extend({
             surveyController.set('studyId', attrs.password);
             surveyController.set('participantId', attrs.username);
             this.set('authenticating', false);
-            this.transitionToRoute('participate.survey.consent');
+
+            if (!siteNames.includes(attrs.password)) {
+              // Do not allow user to attempt login if their study ID is not known to the current version of this code.
+              //   This is a safety mechanism in case of improperly created accounts. It prevents people from seeing a
+              //   blank page in place of a consent form, but users should never see this error. We intentionally only
+              //   check this after the user has logged in and verified a real account, to avoid confusing users who
+              //   happened to mistype their credentials.
+              alert('You have entered an unrecognized study ID. Please contact your study coordinator for more information');
+            } else {
+              this.transitionToRoute('participate.survey.consent');
+            }
           })
           .catch((e) => {
             this.set('authenticating', false);


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-351

## Purpose
Do not allow users to do the study- even if their credentials are valid- unless the study ID associated with the account is recognized.

If the user has an unknown study ID, they would see a blank consent form with a checkbox. This is designed to improve the user experience be safeguarding against user accounts that were created with a typo, or against outdated site IDs.

Every user who logs in should see a consent form.

## Summary of changes
If the study ID does not have a matching consent form (as laid out in consentText.js), prevent login and show an alert message. No regular user should ever see this message because we should be verifying that accounts are correct before sending credentials out to participants.

Because this is intended to be a last resort safeguard, this message is not translated at this time.

<img width="562" alt="screen shot 2017-01-13 at 11 50 17 pm" src="https://cloud.githubusercontent.com/assets/2957073/21952470/6f11480c-d9eb-11e6-9992-6fb549616390.png">


## Testing notes
Use experimenter to create 2 accounts:
- An account with a known study ID (eg `test` or `USA1.ENG`)
- An account with a study ID that does not have a matching study ID (`kerfufflegate`)

Then:
1. Log in using a valid account with a known study ID. Confirm you can log in, see the correct consent form for that study, and enter the survey.
2. Return to the homepage and refresh the page. Login using a valid account with an unknown study ID. Confirm that you see the message in the screenshot above.
3. Return to the homepage and refresh the page. Try to login, but spell the username or study ID incorrectly. Confirm that the normal login error message shows up (not the special secret message).
