### PR TITLE
Add Croatian + Danish translations + English site consent forms

### DIFF
--- a/app/components/isp-consent-form/consentText.js
+++ b/app/components/isp-consent-form/consentText.js
@@ -175,6 +175,17 @@ const consentText = {
         "title": "Consent to Participate in Research",
         "versionHistory": "(Consent form version: 14 October 2016)"
     },
+    "INDIA1.ENG": {
+        "buttonLabel": "Please accept terms to continue",
+        "consentLabel": "I have read and understand the above statements and agree to participate.",
+        "paragraphs": [
+            "Welcome to our study. Your participation will be in one session and will take less than one hour. You will be asked to describe a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes.  At the end of the study, if you choose, you will receive personalized information about your personality.",
+            "All of your responses will be confidential and identified only by a number (and not by your name).  For research purposes, these anonymous data may be archived in an online database maintained by the Center for Open Science (www.cos.io). Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty. The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts.  There are no known risks.",
+            "If you have any questions about this study or your rights as a participant, you may contact Anagha Lavalekar, anagha.lavalekar@jnanaprabodhini.org, Jnana Prabodihini’s Institute of Psychology, Pune, who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
+        ],
+        "title": "Consent to Participate in Research",
+        "versionHistory": "(Consent form version: 14 October 2016)"
+    },
     "NEWZ1.ENG": {
         "buttonLabel": "Please accept terms to continue",
         "consentLabel": "I have read and understand the above statements and agree to participate.",
@@ -197,6 +208,17 @@ const consentText = {
         "title": "Consent to Participate in Research",
         "versionHistory": "(Consent form version: 14 October 2016)"
     },
+    "PAKI1.ENG": {
+        "buttonLabel": "Please accept terms to continue",
+        "consentLabel": "I have read and understand the above statements and agree to participate.",
+        "paragraphs": [
+            "Welcome to our study. Your participation will be in one session and will take less than one hour. You will be asked to describe a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes.  At the end of the study, if you choose, you will receive personalized information about your personality.",
+            "All of your responses will be confidential and identified only by a number (and not by your name).  For research purposes, these anonymous data may be archived in an online database maintained by the Center for Open Science (www.cos.io). Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty. The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts.  There are no known risks.",
+            "If you have any questions about this study or your rights as a participant, you may contact Muhammad Rizwan, muhammad29psy@yahoo.com, University of Karachi, who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
+        ],
+        "title": "Consent to Participate in Research",
+        "versionHistory": "(Consent form version: 14 October 2016)"
+    },
     "PHIL1.ENG": {
         "buttonLabel": "Please accept terms to continue",
         "consentLabel": "I have read and understand the above statements and agree to participate.",
@@ -215,6 +237,17 @@ const consentText = {
             "Welcome to our study. Your participation will be in one session and will take less than one hour. You will be asked to describe a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes.  At the end of the study, if you choose, you will receive personalized information about your personality.",
             "All of your responses will be confidential and identified only by a number (and not by your name).  For research purposes, these anonymous data may be archived in an online database maintained by the Center for Open Science (www.cos.io). Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty.  The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts.  There are no known risks.",
             "If you have any questions about this study or your rights as a participant, you may contact Ryan Hong, ryan.hong@nus.edu.sg, the National University of Singapore, who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
+        ],
+        "title": "Consent to Participate in Research",
+        "versionHistory": "(Consent form version: 14 October 2016)"
+    },
+    "UAE1.ENG": {
+        "buttonLabel": "Please accept terms to continue",
+        "consentLabel": "I have read and understand the above statements and agree to participate.",
+        "paragraphs": [
+            "Welcome to our study. Your participation will be in one session and will take less than one hour. You will be asked to describe a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes.  At the end of the study, if you choose, you will receive personalized information about your personality.",
+            "All of your responses will be confidential and identified only by a number (and not by your name).  For research purposes, these anonymous data may be archived in an online database maintained by the Center for Open Science (www.cos.io). Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty. The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts.  There are no known risks.",
+            "If you have any questions about this study or your rights as a participant, you may contact Mark Aveyard, maveyard@aus.edu, American University of Sharjah, who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
         ],
         "title": "Consent to Participate in Research",
         "versionHistory": "(Consent form version: 14 October 2016)"
@@ -258,18 +291,29 @@ const consentText = {
         "paragraphs": [
             "Welcome to our study. Your participation will be in one session and will take less than one hour. You will be asked to describe a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes.  At the end of the study, if you choose, you will receive personalized information about your personality.",
             "All of your responses will be confidential and identified only by a number (and not by your name). For research purposes, these anonymous data may be archived in an online database maintained by the Center for Open Science (www.cos.io). Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty. The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts. There are no known risks.",
-            "If you have any questions about this study or your rights as a participant, you may contact Nair\u00e1n Ram\u00edrez-Esparza, nairan.ramirez@uconn.edu, the University of Connecticut, who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
+            "If you have any questions about this study or your rights as a participant, you may contact Nairán Ramírez-Esparza, nairan.ramirez@uconn.edu, the University of Connecticut, who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
         ],
         "title": "Consent to Participate in Research",
         "versionHistory": "(Consent form version: 14 October 2016)"
     },
-    "USA4.ENG": {
+    "USA4.US": {
         "buttonLabel": "Please accept terms to continue",
         "consentLabel": "I have read and understand the above statements and agree to participate.",
         "paragraphs": [
             "Welcome to our study. Your participation will be in one session and will take less than one hour. You will be asked to describe a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes.  At the end of the study, if you choose, you will receive personalized information about your personality.",
             "All of your responses will be confidential and identified only by a number (and not by your name).  For research purposes, these anonymous data may be archived in an online database maintained by the Center for Open Science (www.cos.io). Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty. The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts.  There are no known risks.",
             "If you have any questions about this study or your rights as a participant, you may contact Eric Stocks, estocks@uttyler.edu, the University of Texas,Tyler, who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
+        ],
+        "title": "Consent to Participate in Research",
+        "versionHistory": "(Consent form version: 14 October 2016)"
+    },
+    "USA5.ENG": {
+        "buttonLabel": "Please accept terms to continue",
+        "consentLabel": "I have read and understand the above statements and agree to participate.",
+        "paragraphs": [
+            "Welcome to our study. Your participation will be in one session and will take less than one hour. You will be asked to describe a situation you experienced recently and your behaviors in it. You will also be asked some questions about your values and attitudes.  At the end of the study, if you choose, you will receive personalized information about your personality.",
+            "All of your responses will be confidential and identified only by a number (and not by your name).  For research purposes, these anonymous data may be archived in an online database maintained by the Center for Open Science (www.cos.io). Each question must be answered in order to complete this survey, but you can discontinue your participation at any time without penalty. The potential benefits of this research include improving the understanding of persons and their lives across cultural contexts.  There are no known risks.",
+            "If you have any questions about this study or your rights as a participant, you may contact Joey Cheng, chengjoe@illinois.edu, University of Illinois at Champaign-Urbana, who is responsible for data collection at your location, or the University of California, Riverside, Office of Research Integrity by email at IRB@ucr.edu. We sincerely appreciate your cooperation."
         ],
         "title": "Consent to Participate in Research",
         "versionHistory": "(Consent form version: 14 October 2016)"

--- a/app/components/isp-consent-form/consentText.js
+++ b/app/components/isp-consent-form/consentText.js
@@ -50,6 +50,18 @@ const consentText = {
         "title": "知情同意书",
         "versionHistory": "（知情同意书版本：2016年11月14日）"
     },
+    //Croatian
+    "CROA1.HR": {
+        "buttonLabel": "Molimo, prihvatite uvjete kako biste mogli nastaviti.",
+        "consentLabel": "Pročitao sam i razumijem prethodne izjave i pristajem sudjelovati.",
+        "paragraphs": [
+            "Dobro došli u naše istraživanje. Vaše će sudjelovanje biti jednokratno i trajat će manje od jednog sata. Od Vas se očekuje da opišete  situaciju u kojoj ste se nedavno našli i svoja ponašanja u toj situaciji. Bit će Vam postavljena i neka pitanja o Vašim vrijednostima i stavovima. Ako želite, po završetku istraživanja možete dobiti povratnu informaciju o svojim osobinama ličnosti.",
+            "Svi vaši odgovori bit će povjerljivi i označeni samo brojem (a ne Vašim imenom i prezimenom). Za istraživačke svrhe ti anonimni podaci mogu biti arhivirani u online bazu podataka koju vodi američki Centar za otvorene znanosti (www.cos.io). Da biste završili upitnik morate odgovoriti na svako pitanje, ali sudjelovanje  možete prekinuti u svakom trenutku bez ikakvih posljedica. Ono što želimo dobiti ovim istraživanjem uključuje bolje poznavanje osoba i njihova života u različitim kulturalnim kontekstima. Sudjelovanje u ovom istraživanju Vam neće naštetiti.",
+            "Imate li bilo kakva pitanja o ovom istraživanju ili svojim pravima kao sudionik istraživanja, možete se obratiti prof. dr. Željku Jerneiću (zjerneic@ffzg.hr), Odsjek za psihologiju Filozofskog fakulteta Sveučilišta u Zagrebu, koji je odgovoran za prikupljanje podataka u Republici Hrvatskoj ili  na adresu e-pošte IRB@ucr.edu (University of California, Riverside, Office of Research Integrity) . Zahvaljujemo Vam na suradnji."
+        ],
+        "title": "Pristanak na sudjelovanje u istraživanju",
+        "versionHistory": "(Pristanak oblik verzija: 14. listopada 2016)"
+    },
     // German
     "GERM1.AU": {
         "buttonLabel": "Bitte akzeptieren Sie die Teilnahmebedingungen, um fortzufahren.",

--- a/app/components/isp-consent-form/consentText.js
+++ b/app/components/isp-consent-form/consentText.js
@@ -62,6 +62,18 @@ const consentText = {
         "title": "Pristanak na sudjelovanje u istraživanju",
         "versionHistory": "(Pristanak oblik verzija: 14. listopada 2016)"
     },
+    // Danish
+    "DANI1.DK": {
+        "buttonLabel": "Venligst acceptér vilkårene for at fortsætte",
+        "consentLabel": "Jeg har læst og forstået det ovenfor beskrevne og er indforstået med at deltage i studiet.",
+        "paragraphs": [
+            "Velkommen til vores studie. Din deltagelse er en session som alt i alt vil tage under 1 time. Du vil blive bedt om at beskrive en situation, som du for nyligt har oplevet, og den adfærd som du havde i den situation. Du vil også blive stillet nogle spørgsmål vedrørende dine værdier og holdninger. I slutningen af studiet, hvis du vælger dette, vil du modtage information om og feedback på din personlighed.",
+            "Alle dine svar er fortrolige og vil kun kunne identificeres via et nummer (og derfor ikke dit navn). Af hensyn til forskningens formål vil de anonymiserede data kunne blive opbevaret i en online database, som vedligeholdes af Center for Open Science (www.cos.io). Hvert spørgsmål skal besvares for at fuldføre spørgeskemaet, men du kan helt problemfrit afbryde din deltagelse på et hvilket som helst tidspunkt. Det forventede bidrag ved dette forskningsstudium er forbundet med at øge vores forståelse af personer og deres liv på tværs af kulturelle kontekster. Der er ikke nogen kendte risici forbundet med studiet.",
+            "Hvis du har spørgsmål til studiet eller dine rettigheder som deltager i dette kan du kontakte Pernille S. Strøbæk, adjunkt ved Institut for Psykologi, Københavns Universitet, på email Pernille.Stroebaek@psy.ku.dk; hun er ansvarlig for indsamling af data i Danmark. Du kan også kontakte University of California, Riverside, Office of Research Integrity på email IRB@ucr.edu. Vi sætter overordentlig stor pris på din deltagelse."
+        ],
+        "title": "Samtykke til at deltage i denne forskning.",
+        "versionHistory": "(Samtykkeerklæring udgave: 14 oktober 2016)"
+    },
     // German
     "GERM1.AU": {
         "buttonLabel": "Bitte akzeptieren Sie die Teilnahmebedingungen, um fortzufahren.",

--- a/app/components/isp-consent-form/consentText.js
+++ b/app/components/isp-consent-form/consentText.js
@@ -320,7 +320,7 @@ const consentText = {
         "title": "Consent to Participate in Research",
         "versionHistory": "(Consent form version: 14 October 2016)"
     },
-    "USA4.US": {
+    "USA4.ENG": {
         "buttonLabel": "Please accept terms to continue",
         "consentLabel": "I have read and understand the above statements and agree to participate.",
         "paragraphs": [

--- a/app/locales/da/config.js
+++ b/app/locales/da/config.js
@@ -1,0 +1,16 @@
+// Ember-I18n includes configuration for common locales. Most users
+// can safely delete this file. Use it if you need to override behavior
+// for a locale or define behavior for a locale that Ember-I18n
+// doesn't know about.
+export default {
+  rtl: false,
+
+  pluralForm: function(count) {
+    if (count === 0) { return 'zero'; }
+    if (count === 1) { return 'one'; }
+    if (count === 2) { return 'two'; }
+    if (count < 5) { return 'few'; }
+    if (count >= 5) { return 'many'; }
+    return 'other';
+  }
+};

--- a/app/locales/da/translations.js
+++ b/app/locales/da/translations.js
@@ -1,0 +1,1103 @@
+export default {
+    "0": "0",
+    "1": "1",
+    "10": "10",
+    "100": "100",
+    "11": "11",
+    "12": "12",
+    "13": "13",
+    "14": "14",
+    "15": "15",
+    "16": "16",
+    "17": "17",
+    "18": "18",
+    "19": "19",
+    "2": "2",
+    "20": "20",
+    "21": "21",
+    "22": "22",
+    "23": "23",
+    "24": "24",
+    "25": "25",
+    "26": "26",
+    "27": "27",
+    "28": "28",
+    "29": "29",
+    "3": "3",
+    "30": "30",
+    "31": "31",
+    "32": "32",
+    "33": "33",
+    "34": "34",
+    "35": "35",
+    "36": "36",
+    "37": "37",
+    "38": "38",
+    "39": "39",
+    "4": "4",
+    "40": "40",
+    "41": "41",
+    "42": "42",
+    "43": "43",
+    "44": "44",
+    "45": "45",
+    "46": "46",
+    "47": "47",
+    "48": "48",
+    "49": "49",
+    "5": "5",
+    "50": "50",
+    "51": "51",
+    "52": "52",
+    "53": "53",
+    "54": "54",
+    "55": "55",
+    "56": "56",
+    "57": "57",
+    "58": "58",
+    "59": "59",
+    "6": "6",
+    "60": "60",
+    "61": "61",
+    "62": "62",
+    "63": "63",
+    "64": "64",
+    "65": "65",
+    "66": "66",
+    "67": "67",
+    "68": "68",
+    "69": "69",
+    "7": "7",
+    "70": "70",
+    "71": "71",
+    "72": "72",
+    "73": "73",
+    "74": "74",
+    "75": "75",
+    "76": "76",
+    "77": "77",
+    "78": "78",
+    "79": "79",
+    "8": "8",
+    "80": "80",
+    "81": "81",
+    "82": "82",
+    "83": "83",
+    "84": "84",
+    "85": "85",
+    "86": "86",
+    "87": "87",
+    "88": "88",
+    "89": "89",
+    "9": "9",
+    "90": "90",
+    "91": "91",
+    "92": "92",
+    "93": "93",
+    "94": "94",
+    "95": "95",
+    "96": "96",
+    "97": "97",
+    "98": "98",
+    "99": "99",
+    "Key": "Danish Translation",
+    "consent": {
+        "button": {
+            "labelUnaccepted": "Venligst acceptér vilkårene for at fortsætte"
+        },
+        "checkboxLabel": "Jeg har læst og forstået det ovenfor beskrevne og er indforstået med at deltage i studiet.",
+        "firstSection": "Velkommen til vores studie. Din deltagelse er en session som alt i alt vil tage under 1 time. Du vil blive bedt om at beskrive en situation, som du for nyligt har oplevet, og den adfærd som du havde i den situation. Du vil også blive stillet nogle spørgsmål vedrørende dine værdier og holdninger. I slutningen af studiet, hvis du vælger dette, vil du modtage information om og feedback på din personlighed.",
+        "secondSection": "Alle dine svar er fortrolige og vil kun kunne identificeres via et nummer (og derfor ikke dit navn). Af hensyn til forskningens formål vil de anonymiserede data kunne blive opbevaret i en online database, som vedligeholdes af Center for Open Science (www.cos.io). Hvert spørgsmål skal besvares for at fuldføre spørgeskemaet, men du kan helt problemfrit afbryde din deltagelse på et hvilket som helst tidspunkt. Det forventede bidrag ved dette forskningsstudium er forbundet med at øge vores forståelse af personer og deres liv på tværs af kulturelle kontekster. Der er ikke nogen kendte risici forbundet med studiet.",
+        "thirdSection": "Hvis du har spørgsmål til studiet eller dine rettigheder som deltager i dette kan du kontakte Pernille S. Strøbæk, adjunkt ved Institut for Psykologi, Københavns Universitet, på email Pernille.Stroebaek@psy.ku.dk; hun er ansvarlig for indsamling af data i Danmark. Du kan også kontakte University of California, Riverside, Office of Research Integrity på email IRB@ucr.edu. Vi sætter overordentlig stor pris på din deltagelse.",
+        "title": "Samtykke til at deltage i denne forskning.",
+        "versionHistory": "(Samtykkeerklæring udgave: 14 oktober 2016)"
+    },
+    "exitpage": {
+        "line1": "Tak for din deltagelse!",
+        "line2": "Dine svar er blevet gemt"
+    },
+    "feedback": {
+        "agree": "Venlighed",
+        "consc": "Samvittighedsfuldhed",
+        "exitButton": "Afslut",
+        "extra": "Udadvendthed",
+        "firstSection": "Baseret på mange års forskning er personlighedsforskere enige om, at de vigtigste individuelle forskelle i personlighedstræk kan beskrives gennem  fem grundlæggende træk, også kendt som femfaktormodellen (”Big Five”): Udadvendthed, Venlighed, Samvittighedsfuldhed, Følelsesmæssig stabilitet samt Åbenhed over for Oplevelser.\nDet spørgeskema, du netop har afsluttet, giver en score på hvert af disse træk, og dine resultater er beskrevet nedenfor.",
+        "fourthSection": "Tak for din deltagelse!",
+        "hiAgree": "Dem som scorer højt har en tendens til at være hensynsfulde og høflige i sociale interaktioner og nyder at samarbejde med andre. De finder det let at stole på andre mennesker og har medfølelse med dem, som er i nød. Dem som scorer højt har en tendens til at være vellidte af deres kammerater, og de etablerer tilfredsstillende og stabile tætte relationer. De er mere tilbøjelige til at være religiøse, at påtage sig lederroller i lokalmiljøet og at udføre frivilligt arbejde. Ældre voksne har en tendens til at score højere end yngre voksne.",
+        "hiConsc": "Dem som scorer højt har en tendens til at være organiserede og ansvarlige. De arbejder hårdt for at nå deres mål og fuldfører de opgaver, de er begyndt på. Dem som scorer højt har tendens til at få højere karakterer i skolen og klarer sig bedre inden for mange erhverv. De er mere tilbøjelige til at være religiøse og at have konservative politiske holdninger. De har tendens til at motionere mere, har en bedre fysisk sundhed og lever længere. Ældre voksne har en tendens til at score højere end yngre voksne.",
+        "hiExtra": "De som scorer højt har en tendens til at være snaksalig og energisk. De kan lide at være sammen med mennesker og føler sig tilpas med at udtrykke sig selv i en gruppe.  En høj scorer viser en tendens til at have flere venner og flere dating partnere, og de anses som populære. De er mere tilbøjelige til at have ledende roller i det lokale miljø og til at udføre frivilligt arbejde. De har tendens til at foretrække tempofyldt musik, de motionerer oftere og er mere tilbøjelige til at gå til en sportsaktivitet. De oplever hyppigere positive følelser og reagerer stærkere på positive begivenheder.",
+        "hiNeurot": "Dem, der scorer højt tendens til at være følelsesmæssigt stabil og robust. De bevarer som regel roligt, selv i stressede situationer og \ninddrive hurtigt efter negative begivenheder. Dem, der scorer højt på følelsesmæssig stabilitet tendens til at have en større følelse af velvære.",
+        "hiOpen": "Dem som scorer højt er generelt åbne over for nye aktiviteter og nye ideer. De har en tendens til at være kreative, intellektuelt nysgerrige, og at være modtagelige overfor kunst og skønhed. Dem som scorer højt har en tendens til at foretrække, og er bedre til, videnskabelige og kunstneriske erhverv. De lytter helst til klassisk musik, jazz, blues, og rockmusik.",
+        "labels": {
+            "high": "Høj",
+            "low": "Lav",
+            "medium": "Medium"
+        },
+        "loAgree": "Dem som scorer lavt udtrykker sig direkte og uden omsvøb, selv hvis der er risiko for at det starter et skænderi. De nyder det konkurrencebetonede og har tendens til at være skeptiske over for andre menneskers intentioner. Dem som scorer lavt har en tendens til at tjene flere penge og er mere tilbøjelige til at engagere sig i risikobetonet adfærd, såsom rygning og aggressiv kørsel i trafikken.",
+        "loConsc": "Dem som scorer lavt har en tendens til at handle spontant i stedet for at lave planer, og de finder det lettere at se det store billede end at være opmærksom på små detaljer. De foretrækker at  springe rundt  mellem forskellige opgaver i stedet for at færdiggøre én opgave ad gangen. De har tendens til at engagere sig i mere risikobetonet adfærd, såsom rygning, alkoholindtag og brug af stoffer.",
+        "loExtra": "Dem som scorer lavt har en tendens til at være socialt og følelsesmæssigt reserverede. De foretrækker generelt at være alene eller sammen med nogle ganske få nære venner, og de holder deres meninger og følelser for sig selv. De er mindre tilbøjelige til at engagere sig i spændingssøgende aktiviteter eller i risikobetonet adfærd såsom rygning og alkoholindtagelse.",
+        "loNeurot": "Dem som scorer lavt har en tendens til at være følelsesmæssigt sensitive og at have op-og-ned humørsvingninger. De oplever hyppigere negative følelser og reagerer stærkere på negative begivenheder. Yngre voksne har tendens til at score lavere end ældre voksne.",
+        "loOpen": "Dem som scorer lavt har en tendens til at være traditionelle, praktiske, og kan bedst lide at holde sig til de gængse måder at gøre tingene på. De foretrækker det velkendte over det nye, og det konkrete over det abstrakte. Dem som scorer lavt har en tendens til at foretrække, og er bedre til, de traditionelle og praktiske erhverv, såsom håndværk og handel.",
+        "neurot": "Følelsesmæssig Stabilitet",
+        "open": "Åbenhed over for Oplevelser",
+        "score": "Din score ud af 100 totalt mulige:",
+        "secondSection": "For hvert træk kan en score på over 60 betragtes som en høj score, og en score på under 40 kan betragtes som en lav score. Angivelser af høje og lave scores vises nedenfor. Hvis din score er mellem 40 og 60 vil din personlighed sandsynligvis bedst beskrives som værende omkring gennemsnittet på de anførte karaktertræk.",
+        "thirdSection": "Vi håber du har fundet det spændende at deltage i dette studie.",
+        "title": "Din personlighed"
+    },
+    "flag": {
+        "chooseLanguage": "Vælg sprog"
+    },
+    "global": {
+        "agreement": {
+            "agree": "Enig",
+            "agreeStrongly": "Meget enig",
+            "disagree": "Uenig",
+            "disagreeStrongly": "Meget uenig",
+            "neutral": "Neutral, ingen holdning til det"
+        },
+        "char": {
+            "extremelyChar": "Ekstremt karakteristisk",
+            "extremelyUnchar": "Ekstremt ukarakteristisk",
+            "fairlyChar": "Rimelig karakteristisk",
+            "fairlyUnchar": "Rimelig ukarakteristisk",
+            "neutral": "Hverken karakteristisk eller ukarakteristisk",
+            "quiteChar": "Temmelig karakteristisk",
+            "quiteUnchar": "Temmelig ukarakteristisk",
+            "somewhatChar": "Noget karakteristisk",
+            "somewhatUnchar": "Noget ukarakteristisk"
+        },
+        "continueLabel": "Fortsæt",
+        "describe": {
+            "aGreatDeal": "En hel del",
+            "aLittle": "En smule",
+            "notAtAll": "Slet ikke"
+        },
+        "noLabel": "Nej",
+        "previousLabel": "Forrige side",
+        "progress": "Fortsæt",
+        "selectUnselected": "Vælg:",
+        "yesLabel": "Ja"
+    },
+    "login": {
+        "changeButton": "Skift sprog",
+        "defaultError": "Prøv venligst igen senere",
+        "errorHeading": "Der er opstået en fejl ved login",
+        "invalidAuthError": "Ugyldigt studie ID eller deltager ID",
+        "participantID": "Deltager ID",
+        "studyID": "Studie ID",
+        "youChose": "Vælg:"
+    },
+    "measures": {
+        "questions": {
+            "1": {
+                "label": "Overordnet set, var den situation, som du beskrev, en positiv eller en negativ oplevelse?",
+                "options": {
+                    "extremelyNeg": "Ekstremt negativ",
+                    "extremelyPos": "Ekstremt positiv",
+                    "fairlyNeg": "Temmelig negativ",
+                    "fairlyPos": "Temmelig positiv",
+                    "neither": "Hverken negativ eller positiv",
+                    "quiteNeg": "Aldeles negativ",
+                    "quitePos": "Aldeles positiv",
+                    "somewhatNeg": "I nogen grad negativ",
+                    "somewhatPos": "I nogen grad positiv"
+                }
+            },
+            "10": {
+                "items": {
+                    "1": {
+                        "label": "Der er mange sociale normer, som folk forventes at overholde i dette land."
+                    },
+                    "2": {
+                        "label": "I dette land er der meget klare forvetninger til, hvordan folk skal opføre sig i de fleste situationer."
+                    },
+                    "3": {
+                        "label": "Folk i dette land er i de fleste situationer enige om, hvilken adfærd der er passende og hvilken der er upassende,"
+                    },
+                    "4": {
+                        "label": "Folk i dette land har stor frihed til at afgøre, hvordan de vil opføre sig i de fleste situationer."
+                    },
+                    "5": {
+                        "label": "Hvis nogen i dette land opfører sig på en upassende måde vil andre dømme dem hårdt for det."
+                    },
+                    "6": {
+                        "label": "Folk i dette land følger næsten altid de sociale normer."
+                    }
+                },
+                "label": "Angiv i hvilken grad du er enig eller uenig med de følgende udsagn:",
+                "options": {
+                    "agree": "Enig",
+                    "agreeStrongly": "Meget enig",
+                    "disagree": "Uenig",
+                    "disagreeStrongly": "Meget uenig",
+                    "neutral": "Neutral, ingen holdning til det"
+                }
+            },
+            "11": {
+                "label": "Er der et aspekt af din personlighed, som du for tiden prøver at ændre på?",
+                "options": {
+                    "no": "Nej",
+                    "yes": "Ja"
+                }
+            },
+            "12": {
+                "label": "Hvilket aspekt forsøger du at ændre på?"
+            },
+            "13": {
+                "items": {
+                    "1": {
+                        "label": "De fleste mennesker er grundlæggende ærlige."
+                    },
+                    "2": {
+                        "label": "De feste mennesker er grundlæggende godmodige og venlige."
+                    },
+                    "3": {
+                        "label": "De fleste mennesker stoler på andre."
+                    },
+                    "4": {
+                        "label": "Jeg stoler generelt på andre."
+                    },
+                    "5": {
+                        "label": "De fleste mennesker er troværdige."
+                    }
+                },
+                "label": "Angiv i hvilken grad du er enig eller uenig med de følgende udsagn:\nJeg er en som…",
+                "options": {
+                    "agree": "Enig",
+                    "agreeStrongly": "Meget enig",
+                    "disagree": "Uenig",
+                    "disagreeStrongly": "Meget uenig",
+                    "neutral": "Neutral, ingen holdning til det"
+                }
+            },
+            "14": {
+                "items": {
+                    "1": {
+                        "label": "I usikre tider forventer jeg som regel det bedste"
+                    },
+                    "2": {
+                        "label": "Hvis noget kan gå gå galt for mig, går det også galt."
+                    },
+                    "3": {
+                        "label": "Jeg er altid optimitisk omkring min fremtid."
+                    },
+                    "4": {
+                        "label": "Jeg forventer næsten aldrig, at tingene skal gå min vej."
+                    },
+                    "5": {
+                        "label": "Jeg forventer sjældent, at gode ting sker for mig."
+                    },
+                    "6": {
+                        "label": "Overordnet set forventer jeg, at der sker flere gode end dårlige ting for mig ."
+                    }
+                },
+                "label": "Angiv i hvor høj grad du er enig eller uenig i følgende udsagn:",
+                "options": {
+                    "agree": "Enig",
+                    "agreeStrongly": "Meget enig",
+                    "disagree": "Uenig",
+                    "disagreeStrongly": "Meget uenig",
+                    "neutral": "Neutral, ingen holdning til det"
+                }
+            },
+            "15": {
+                "items": {
+                    "1": {
+                        "label": "Jeg ville aldrig prøve at indsmigre mig for at få en lønforhøjelse eller en forfremmelse på arbejdet, heller ikke selvom jeg tror det ville virke."
+                    },
+                    "10": {
+                        "label": "Jeg vil have, at folk skal vide, at jeg er en vigtigt person med en høj status."
+                    },
+                    "2": {
+                        "label": "Hvis jeg ønsker noget fra nogen, griner jeg, når personens laver de værste jokes."
+                    },
+                    "3": {
+                        "label": "Jeg ville ikke foregive at kunne lide en person bare for at få den person til at gøre mig tjenester."
+                    },
+                    "4": {
+                        "label": "Hvis jeg vidste, at jeg aldrig ville blive opdaget, ville jeg være villig til at stjæle en stor sum penge."
+                    },
+                    "5": {
+                        "label": "Jeg ville aldrig tage imod bestikkelse, heller ikke selvom det var en stor en."
+                    },
+                    "6": {
+                        "label": "Jeg ville være fristet til at begå falskmønteri, hvis jeg var sikker på, at jeg kunne slippe afsted med det."
+                    },
+                    "7": {
+                        "label": "At have mange penge er ikke så vigtigt for mig."
+                    },
+                    "8": {
+                        "label": "Jeg ville have meget glæde ud af at eje dyre luksusvarer."
+                    },
+                    "9": {
+                        "label": "Jeg synes, ​​at jeg har ret til at få mere respekt, end en gennemsnitlige person har det."
+                    }
+                },
+                "label": "Angiv i hvilken grad du er enig eller uenig med de følgende udsagn:\nJeg er en som…",
+                "options": {
+                    "agree": "Enig",
+                    "agreeStrongly": "Meget enig",
+                    "disagree": "Uenig",
+                    "disagreeStrongly": "Meget uenig",
+                    "neutral": "Neutral, ingen holdning til det"
+                }
+            },
+            "16": {
+                "items": {
+                    "1": {
+                        "label": "Sammen med familie"
+                    },
+                    "2": {
+                        "label": "Sammen med venner"
+                    },
+                    "3": {
+                        "label": "I den by hvor jeg bor"
+                    },
+                    "4": {
+                        "label": "I samfundet"
+                    },
+                    "5": {
+                        "label": "I verden"
+                    }
+                },
+                "label": "I hvor høj grad synes du, at dit liv tager form inden for følgende af disse kontekster?",
+                "options": {
+                    "aLittle": "En smule",
+                    "completely": "Fuldstændig",
+                    "notAtAll": "Slet ikke",
+                    "quiteaBit": "Ret meget"
+                }
+            },
+            "17": {
+                "items": {
+                    "1": {
+                        "label": "Jeg fortjener at blive set på som en stor personlighed."
+                    },
+                    "2": {
+                        "label": "Det at være en særlig person giver mig meget styrke."
+                    },
+                    "3": {
+                        "label": "Jeg formår at være centrum for opmærksomhed med mine enestående bidrag."
+                    },
+                    "4": {
+                        "label": "De fleste mennesker er lidt nogle tabere."
+                    },
+                    "5": {
+                        "label": "Jeg vil gerne have, at mine rivaler fejler."
+                    },
+                    "6": {
+                        "label": "Jeg reagerer irriteret, hvis en anden person stjæler opmærksomheden fra mig."
+                    }
+                },
+                "label": "Vurder i hvor høj grad du er enig eller uenig i følgende udsagn:",
+                "options": {
+                    "agree": "Enig",
+                    "agreeStrongly": "Meget enig",
+                    "disagree": "Uenig",
+                    "disagreeStrongly": "Meget uenig",
+                    "neutral": "Neutral, ingen holdning til det"
+                }
+            },
+            "18": {
+                "label": "Hvor godt er du lykkes med at ændre på dette aspekt af din personlighed?",
+                "options": {
+                    "alittleSuccessful": "Det er lykkes en smule",
+                    "completelySuccessful": "Det er lykkes helt",
+                    "moderatelySuccessful": "Det er lykkes i nogen grad",
+                    "notatallSuccessful": "Det er slet ikke lykkes",
+                    "verySuccessful": "Det er lykkes meget godt"
+                }
+            },
+            "2": {
+                "label": "Hvor ofte oplever du situationer magen til den, du lige har beskrevet?",
+                "options": {
+                    "hardlyEver": "Næsten aldrig",
+                    "never": "Aldrig",
+                    "occasionally": "Ind i mellem",
+                    "quiteOften": "Ret ofte"
+                }
+            },
+            "3": {
+                "items": {
+                    "1": {
+                        "label": "Jeg prøvede at kontrollere situationen."
+                    },
+                    "10": {
+                        "label": "Jeg fór rundt, bevægede mig omrking."
+                    },
+                    "11": {
+                        "label": "Jeg var interesseret i at høre, hvad nogen havde at sige."
+                    },
+                    "12": {
+                        "label": "Jeg søgte et råd."
+                    },
+                    "13": {
+                        "label": "Jeg handlede på en legende måde."
+                    },
+                    "14": {
+                        "label": "Jeg udtrykte selvmedlidenhed og følelser af at være udsat."
+                    },
+                    "15": {
+                        "label": "Jeg talte med en høj stemmeføring."
+                    },
+                    "16": {
+                        "label": "Jeg udviste stor intelligens."
+                    },
+                    "2": {
+                        "label": "Jeg sagde negative ting om mig selv."
+                    },
+                    "3": {
+                        "label": "Jeg opførte mig konkurrencebetonet."
+                    },
+                    "4": {
+                        "label": "Jeg udtrykte ambitioner."
+                    },
+                    "5": {
+                        "label": "Jeg dominerede situationen."
+                    },
+                    "6": {
+                        "label": "Jeg udviste stor entusiasme og et højt energiniveau."
+                    },
+                    "7": {
+                        "label": "Jeg deltog i fysisk aktivitet."
+                    },
+                    "8": {
+                        "label": "Jeg var koncentreret om eller arbejdede hårdt på en opgave."
+                    },
+                    "9": {
+                        "label": "Jeg var reserveret og stille."
+                    }
+                },
+                "label": "Vurder din egen adfærd i den situation, du har beskrevet:",
+                "options": {
+                    "extremelyChar": "Ekstremt karakteristisk",
+                    "extremelyUnchar": "Ekstremt ukarakteristisk",
+                    "fairlyChar": "Rimelig karakteristisk",
+                    "fairlyUnchar": "Rimelig ukarakteristisk",
+                    "neutral": "Hverken karakteristisk eller ukarakteristisk",
+                    "quiteChar": "Temmelig karakteristisk",
+                    "quiteUnchar": "Temmelig ukarakteristisk",
+                    "somewhatChar": "Noget karakteristisk",
+                    "somewhatUnchar": "Noget ukarakteristisk"
+                }
+            },
+            "4": {
+                "label": "Hvordan ser du sig selv: Er du generelt en person som er fuldt indstillet på at løbe en risiko eller prøver du helst at undgå risici?",
+                "options": {
+                    "fullyPrepared": "Fuldt indstillet på at løbe en risiko",
+                    "unwilling": "Uvillig til at løbe en risiko"
+                }
+            },
+            "5": {
+                "items": {
+                    "1": {
+                        "label": "Er udadvendt og social"
+                    },
+                    "10": {
+                        "label": "Er nysgerrig på mange forskellige ting"
+                    },
+                    "11": {
+                        "label": "Sjældent føler sig ophidset eller ivrig"
+                    },
+                    "12": {
+                        "label": "Har en tendens til at finde fejl ved andre mennesker"
+                    },
+                    "13": {
+                        "label": "Er pålidelig, stabil"
+                    },
+                    "14": {
+                        "label": "Er humørsyg, har op-og-ned humørsvingninger"
+                    },
+                    "15": {
+                        "label": "Er opfindsom, finder på smarte måder at gøre ting på"
+                    },
+                    "16": {
+                        "label": "Har en tendens til at være stille"
+                    },
+                    "17": {
+                        "label": "Føler ikke meget sympati over for andre"
+                    },
+                    "18": {
+                        "label": "Er systematisk, kan godt lide at tingene er i orden"
+                    },
+                    "19": {
+                        "label": "Kan være anspændt"
+                    },
+                    "2": {
+                        "label": "Som er medfølende, har et blødt hjerte"
+                    },
+                    "20": {
+                        "label": "Er fascineret af kunst, musik eller litteratur"
+                    },
+                    "21": {
+                        "label": "Er dominerende, agerer som en leder"
+                    },
+                    "22": {
+                        "label": "Starter skænderier med andre"
+                    },
+                    "23": {
+                        "label": "Har svært ved at komme i gang med opgaver"
+                    },
+                    "24": {
+                        "label": "Føler sig tryg og godt tilpas med mig selv"
+                    },
+                    "25": {
+                        "label": "Undgår intellektuelle, filosofiske diskussioner"
+                    },
+                    "26": {
+                        "label": "Er mindre aktiv end andre mennesker"
+                    },
+                    "27": {
+                        "label": "Har en tilgivende natur"
+                    },
+                    "28": {
+                        "label": "Kan være lidt uforsigtig"
+                    },
+                    "29": {
+                        "label": "Er følelsesmæssigt stabil, bliver ikke let oprevet"
+                    },
+                    "3": {
+                        "label": "Har en tendens til at være uorganiseret"
+                    },
+                    "30": {
+                        "label": "Er meget lidt kreativ"
+                    },
+                    "31": {
+                        "label": "Er sommetider genert, introvert"
+                    },
+                    "32": {
+                        "label": "Er hjælpsom og uegoistisk over for andre"
+                    },
+                    "33": {
+                        "label": "Holder ting pænt og ordentligt"
+                    },
+                    "34": {
+                        "label": "Bekymrer sig meget"
+                    },
+                    "35": {
+                        "label": "Værdsætter kunst og æstetik"
+                    },
+                    "36": {
+                        "label": "Finder det vanskeligt at påvirke andre mennesker"
+                    },
+                    "37": {
+                        "label": "Er sommetider grov over for andre"
+                    },
+                    "38": {
+                        "label": "Er effektiv, får tingene gjort"
+                    },
+                    "39": {
+                        "label": "Ofte føler sig trist"
+                    },
+                    "4": {
+                        "label": "Er afslappet, håndterer fint stress"
+                    },
+                    "40": {
+                        "label": "Er kompleks, en der går med dybe tanker"
+                    },
+                    "41": {
+                        "label": "Er fuld af energi"
+                    },
+                    "42": {
+                        "label": "Er mistroisk over for andres intentioner"
+                    },
+                    "43": {
+                        "label": "Er pålidelig, kan altid regnes med"
+                    },
+                    "44": {
+                        "label": "Har sine følelser under kontrol"
+                    },
+                    "45": {
+                        "label": "Har svært ved at forestille mig ting"
+                    },
+                    "46": {
+                        "label": "Er snaksaglig"
+                    },
+                    "47": {
+                        "label": "Kan være kold og ufølsom"
+                    },
+                    "48": {
+                        "label": "Efterlader et rod, ryder ikke op"
+                    },
+                    "49": {
+                        "label": "Sjældent føler sig nervøs eller bange"
+                    },
+                    "5": {
+                        "label": "Har nogle kunstneriske interesser"
+                    },
+                    "50": {
+                        "label": "Synes at digte og teaterstykker er kedelige"
+                    },
+                    "51": {
+                        "label": "Foretrækker at andre tager styringen"
+                    },
+                    "52": {
+                        "label": "Er venlig, høflig over for andre"
+                    },
+                    "53": {
+                        "label": "Er vedholdende, fortsætter indtil opgaven er løst"
+                    },
+                    "54": {
+                        "label": "Har en tendens til at føle sig nedtrykt"
+                    },
+                    "55": {
+                        "label": "Har kun lidt interesse i abstrakte ideer"
+                    },
+                    "56": {
+                        "label": "Viser en masse entusiasme"
+                    },
+                    "57": {
+                        "label": "Antager kun det bedste om folk"
+                    },
+                    "58": {
+                        "label": "Sommetider opfører sig uansvarligt"
+                    },
+                    "59": {
+                        "label": "Er temperamentsfuld, bliver hurtig følelsesladet"
+                    },
+                    "6": {
+                        "label": "Har en selvsikker personlighed"
+                    },
+                    "60": {
+                        "label": "Er nytænkende, kommer på nye ideer"
+                    },
+                    "7": {
+                        "label": "Er respektfuld, behandler andre med respekt"
+                    },
+                    "8": {
+                        "label": "Er tilbøjelig til at være doven"
+                    },
+                    "9": {
+                        "label": "Opretholder optimismen også efter at have oplevet et tilbageslag"
+                    }
+                },
+                "label": "Angiv i hvilken grad du er enig eller uenig med de følgende udsagn:\nJeg er en som…",
+                "options": {
+                    "agree": "Enig",
+                    "agreeStrongly": "Meget enig",
+                    "disagree": "Uenig",
+                    "disagreeStrongly": "Meget uenig",
+                    "neutral": "Neutral, ingen holdning til det"
+                }
+            },
+            "6": {
+                "items": {
+                    "1": {
+                        "label": "Generelt ser jeg mig selv som",
+                        "options": {
+                            "notHappy": "Ikke en meget glad person",
+                            "veryHappy": "En meget glad person"
+                        }
+                    },
+                    "2": {
+                        "label": "Sammenlignet med de fleste mennesker omkring ser jeg mig selv som",
+                        "options": {
+                            "lessHappy": "Mindre glad",
+                            "moreHappy": "Mere glad"
+                        }
+                    },
+                    "3": {
+                        "label": "Nogle mennesker er generelt set meget glade. De nyder livet, uanset hvad der sker, og de får det meste ud af alting. I hvor høj grad beskriver det også dig?",
+                        "options": {
+                            "aGreatDeal": "Ret meget",
+                            "notAtAll": "Slet ikke"
+                        }
+                    },
+                    "4": {
+                        "label": "Nogle mennesker er generelt set ikke ret glade. Selvom de ikke er deprimerede, ser de aldrig ud til at være helt så glade, som de kunne være. I hvor høj grad beskriver det også dig?",
+                        "options": {
+                            "aGreatDeal": "En hel del",
+                            "notAtAll": "Slet ikke"
+                        }
+                    }
+                },
+                "label": "For hvert af de følgende spørgsmål bedes du angive det punkt på en 7-trinsskala, der bedst beskriver dig:"
+            },
+            "7": {
+                "items": {
+                    "1": {
+                        "label": "Jeg synes, at både jeg selv og dem omkring mig er glade."
+                    },
+                    "2": {
+                        "label": "Jeg føler, at andre omkring mig ser positivt på mig."
+                    },
+                    "3": {
+                        "label": "Jeg gør dem, som betyder noget for mig, glade."
+                    },
+                    "4": {
+                        "label": "Selvom det generelt er helt normalt, så lever jeg et stabilt liv."
+                    },
+                    "5": {
+                        "label": "Jeg har ikke nogen større bekymring eller frygt."
+                    },
+                    "6": {
+                        "label": "Jeg kan gøre, hvad jeg vil, uden at det skaber problemer for andre mennesker."
+                    },
+                    "7": {
+                        "label": "Jeg tror, at mit liv er lige så lykkeligt, som andres omkring mig."
+                    },
+                    "8": {
+                        "label": "Jeg tror, at jeg har opnået den samme levestandard, som andre omkring mig."
+                    },
+                    "9": {
+                        "label": "Generelt set tror jeg tingene fungerer lige så godt for mig, som de gør for andre omkring mig."
+                    }
+                },
+                "label": "Vurder i hvor høj grad du er enig eller uenig i følgende udsagn:",
+                "options": {
+                    "agree": "Enig",
+                    "agreeStrongly": "Meget enig",
+                    "disagree": "Uenig",
+                    "disagreeStrongly": "Meget uenig",
+                    "neutral": "Neutral, ingen holdning til det"
+                }
+            },
+            "8": {
+                "items": {
+                    "1": {
+                        "label": "At være religiøs troende hjælper til at forstå meningen med livet."
+                    },
+                    "10": {
+                        "label": "Kun svage mennesker har brug for en religion."
+                    },
+                    "11": {
+                        "label": "Religion får folk til at flygte fra virkeligheden."
+                    },
+                    "12": {
+                        "label": "At udøve en religion forener mennesker med hinanden."
+                    },
+                    "13": {
+                        "label": "Religiøse mennesker er mere tilbøjelige til at opretholde moralske standarder."
+                    },
+                    "14": {
+                        "label": "Religiøs tro leder mennesker til uvidenskabelig tænkning."
+                    },
+                    "15": {
+                        "label": "Uvidenhed får folk til at tro på et højerestående væsen."
+                    },
+                    "16": {
+                        "label": "Der er beviser for eksistensen af et højerestående væsen overalt for dem, der blot søger efter dets tegn"
+                    },
+                    "17": {
+                        "label": "Religion modsiger videnskaben."
+                    },
+                    "2": {
+                        "label": "Religion hjælper mennesker til at træffe gode valg i deres liv."
+                    },
+                    "3": {
+                        "label": "Religiøs tro bidrager til et godt mentalt helbred."
+                    },
+                    "4": {
+                        "label": "Religion sænker den menneskelige progression."
+                    },
+                    "5": {
+                        "label": "Der er et højerestående væsen, der har magten over verden."
+                    },
+                    "6": {
+                        "label": "Religion gør folk sundere."
+                    },
+                    "7": {
+                        "label": "Religion gør folk gladere."
+                    },
+                    "8": {
+                        "label": "At tro på en religion gør mennesker til gode borgere."
+                    },
+                    "9": {
+                        "label": "Religiøs praksis gør det sværere for folk at tænke selvstændigt."
+                    }
+                },
+                "label": "Angiv i hvilken grad du er enig eller uenig med de følgende udsagn:\nJeg er en som…",
+                "options": {
+                    "believeLittle": "Det tror jeg en smule på",
+                    "believeStrong": "Det tror jeg meget på",
+                    "disbelieveLittle": "Det tror jeg ikke så meget på",
+                    "disbelieveStrong": "Det tror jeg overhovedet ikke på",
+                    "neutral": "Neutral, ingen holdning til det",
+                    "preferNoAnswer": "Jeg foretrækker ikke at svare"
+                }
+            },
+            "9": {
+                "items": {
+                    "1": {
+                        "label": "Du foretrækker at give udtryk for dine tanker og følelser, også selvom det sommetider skaber konflikt."
+                    },
+                    "10": {
+                        "label": "Du opfører dig forskelligt, når du er sammen med forskellige mennesker."
+                    },
+                    "11": {
+                        "label": "Du ser forskelligt på dig selv, når du er sammen med forskellige mennesker."
+                    },
+                    "12": {
+                        "label": "Du ser på dig selv på samme måde, selvom du er i forskellige sociale miljøer."
+                    },
+                    "13": {
+                        "label": "Du opfører dig på samme måde, selvom du er sammen med forskellige mennesker."
+                    },
+                    "2": {
+                        "label": "Du prøver at tilpasse dig mennesker omkring dig, selvom det betyder at skjule dine følelser."
+                    },
+                    "3": {
+                        "label": "Du foretrækker at opretholde harmonien i dine relationer, også hvis det betyder at du ikke kan udtrykke dine sande følelser."
+                    },
+                    "4": {
+                        "label": "Du synes det er godt at give åbent udtryk for det, når du er uenig med andre."
+                    },
+                    "5": {
+                        "label": "Du beskytter dine egne interesser, også selvom det undertiden kan forstyrre dine familieforhold."
+                    },
+                    "6": {
+                        "label": "Du sætter som regel andre højere end dig selv."
+                    },
+                    "7": {
+                        "label": "Du passer på de mennesker, som er tæt på dig, også selvom det betyder at du skal sætte dine egne personlige behov til side."
+                    },
+                    "8": {
+                        "label": "Du sætter personlige resultater højere end gode relationer til mennesker tæt på dig."
+                    },
+                    "9": {
+                        "label": "Du ville ofre dine egne personlige interesser hvis det er til gavn for din familie."
+                    }
+                },
+                "label": "Hvor godt beskriver disse udsagn dig?",
+                "options": {
+                    "aLittle": "Beskriver mig en smule",
+                    "exactly": "Beskriver mig fuldstændigt",
+                    "moderately": "Beskriver mig nogenlunde",
+                    "notAtAll": "Beskriver mig slet ikke",
+                    "veryWell": "Beskriver mig meget godt"
+                }
+            }
+        }
+    },
+    "previouslogin": {
+        "line1": "Vores registreringer viser, at du allerede har gennemført denne undersøgelse.",
+        "line2": "Hvis dette er en fejl bedes du tage kontakt til din lokale International Situation Project ansvarlige."
+    },
+    "qsort": {
+        "rsq": {
+            "item": {
+                "SomoneCountedon": "En tilstedeværende person (som ikke er dig selv) regner med at foretage sig noget.",
+                "abusedVictimized": "Du bliver overfuset eller offergøres.",
+                "adviceYou": "Andre ønsker dit råd.",
+                "ambition": "Ambitioner kan udtrykkes eller fremføres.",
+                "anxietyInducing": "Situationen er potentielt angstfremkaldende.",
+                "art": "Kunst er et vigtigt element i situationen.",
+                "askingYou": "Nogen beder dig om noget.",
+                "assertivenessGoal": "Det er nødvendigt med selvsikkerhed for at opnå et mål.",
+                "athleticsSports": "Folk deltager i atlektik eller sportsaktiviteter.",
+                "blaming": "Nogen bebrejder dig for noget.",
+                "breakingRules": "Nogen bryder reglerne.",
+                "clearRules": "Der er klare regler for den passende adfærd (uanset om reglerne bliver fulgt eller ej)",
+                "closeRelationships": "De tilstedeværende personer har tætte personlige relationer til hinanden.",
+                "comparingThemselves": "Personer sammenligner sig selv med hinanden.",
+                "competing": "Folk konkurrerer med hinanden.",
+                "complex": "Situationen er kompleks.",
+                "complimentingYou": "Nogen giver dig et kompliment eller roser dig.",
+                "conformToOthers": "Du er blevet presset til at handle i overensstemmelse med andres handlinger.",
+                "convinceYou": "Nogen prøver at overbevise dig om noget.",
+                "countingOnYou": "Nogen regner med, at du foretager dig noget.",
+                "criticizing": "Nogen kritiserer dig.",
+                "decision": "En beslutning skal træffes.",
+                "desiresGratified": "Lyster kan blive tilfredsstillet (f.eks. mad, shopping eller seksuelle muligheder).",
+                "differentRoles": "De tilstedeværnde personer har forskellige sociale roller eller statusniveauer.",
+                "disagreeing": "Folk er uenige om noget.",
+                "dominate": "Nogen prøver at dominere eller at hundse med dig.",
+                "emotionalThreats": "Følelsesmæssige trusler er til stede.",
+                "emotionsExpressed": "Følelser kan udtrykkes.",
+                "entertainment": "Underholdning er tilstedeværende.",
+                "family": "Familie er vigtigt i denne situation.",
+                "feelInadequate": "Situationen kan få dig til at føle dig utilstrækkelig.",
+                "femininity": "Der kan udtrykkes femininitet.",
+                "food": "Mad er vigtigt i denne situation.",
+                "frustrating": "Situationen er frustrerende (f.eks.: et mål er blokeret).",
+                "goodImpression": "Det er vigtigt, at du gør et godt indtryk.",
+                "happeningOnce": "Der sker mange ting på en gang.",
+                "honor": "Der er et spørgsmål om ære på spil.",
+                "hostile": "Situationen kan få folk til at føle fjendskab.",
+                "humorous": "Situationen er humoristisk eller kan blive humoristisk.",
+                "intellectuallyStimulating": "Situationen kan blive intellektuelt stimulerende.",
+                "intelligence": "Intelligens er vigtigt (f.eks. en intellektuel diskussion eller et komplekst problem, der skal løses).",
+                "jobDone": "Et stykke arbejde skal gøres.",
+                "masculinity": "Der kan udtrykkes maskulinitet.",
+                "minorDetails": "Små detaljer er vigtige.",
+                "money": "Penge er vigtigt.",
+                "moralIssues": "Moralske eller etiske emner er relevante.",
+                "music": "Musik er et vigtigt element i denne situation.",
+                "needsHelp": "Nogen har brug for hjælp.",
+                "negativeEmotions": "Situationen kan fremprovokere negative følelser.",
+                "newRelationships": "Nye parforhold kan opstå.",
+                "noisy": "Situationen er larmende (en lav placering betyder at situationen er meget stille).",
+                "notClear": "Det er ikke klart, hvad der foregår; situationen er uklar.",
+                "oppositeSex": "Det er et vigtigt element i situationen, at der er andre af det modsatte køn end dig selv til stede.",
+                "peopleGetAlong": "Det er vigtigt for folk at enes.",
+                "physicalAttractiveness": "Det er vigtigt, at du er fysisk attraktiv.",
+                "physicalThreats": "Fysiske trusler er til stede.",
+                "physicallyActive": "Folk er fysisk aktive.",
+                "physicallyUncomfortable": "Situationen er fysisk set ubehagelig (f.eks.: det er for varmt, for mange mennesker, for koldt, etc.) (en lav placering er udtryk for at situationen fysisk set er meget behagelig).",
+                "playful": "Situationen er sjov.",
+                "politics": "Politik er relevant (f.eks. en politisk diskussion).",
+                "positiveEmotions": "Situationen kan fremprovokere positive følelser.",
+                "potentiallyEnjoy": "Situationen er potentiel behagelig.",
+                "power": "Magt er vigtigt.",
+                "quickAction": "Det er nødvendigt med hurtig handlen.",
+                "rapidlyChanging": "Situationen skifter hurtigt.",
+                "reassurance": "Nogen har brug for eller ønsker beroligelse.",
+                "reassuringPresent": "En beroligende person er til stede.",
+                "relevantHealth": "Situationen er af betydning for dit helbred (f.eks. mulig sygdom eller et lægebesøg).",
+                "religion": "Religion er relevant i situationen (f.eks. en gudstjeneste eller en diskussion).",
+                "romanticPartners": "Potentielle eller faktiske romantiske partnere (for dig) er til stede.",
+                "ruminateDaydream": "Det er muligt at gruble, dagdrømme eller fantasere.",
+                "selfControl": "Selvbeherskelse er nødvendig (for dig selv eller for andre).",
+                "sensations": "Sanser er vigtige (f.eks. berøring, smag, lugt, fyisk kontakt).",
+                "sexuality": "Seksualitet er relevant.",
+                "shame": "Nogen skammer sig.",
+                "simpleClearcut": "Situationen er simpel og ligetil.",
+                "smallAnnoyances": "I situationen er der små irritationsmomenter.",
+                "socialInteraction": "Social interaktion er mulig.",
+                "successCooperation": "Det kræver samarbejde for at opnå succes.",
+                "takenCareOf": "Nogen har brug for at blive taget hånd om.",
+                "talkingExpected": "Tale er forventet eller påkrævet.",
+                "talkingPermitted": "Det er tilladt at tale.",
+                "tenseUpset": "Situationen kan gøre folk anspændte eller oprevede.",
+                "tryingImpress": "Nogen prøver at imponere dig.",
+                "underThreat": "Nogen er truet.",
+                "unhappySuffering": "Nogen er ulykkelig eller lider.",
+                "unusualIdeas": "Usædvanlige ideer eller synspunkter bliver frit diskuteret.",
+                "verbalFluency": "Der er mulighed for at udtrykke sig i fri tale (f.eks. en debat, en monolog eller en aktiv samtale).",
+                "workingHard": "Folk arbejder hårdt.",
+                "youFocus": "Du er i fokus for opmærksomhed."
+            }
+        },
+        "sections": {
+            "1": {
+                "activity": "Aktivitet:",
+                "categories": {
+                    "characteristic": "Karakteristisk",
+                    "neutral": "Neutral",
+                    "uncharacteristic": "Ukarakteristisk"
+                },
+                "instructions": "Vær venlig at beskrive den situation som du oplevede i lidt flere detaljer. 90 items vil komme frem et ad gangen. Placér hvert item i en af de tre boxe. Brug \"Karaktersitisk\" boxen til højre til items, der præcist beskriver situationen; brug \"Ukarakteristisk\" boxen til venstre til items, som er ubeskrivende for situationen; og brug \"Neutral\" boxen til items som er irrelevante, uklare eller som du er i tvivl om. Når du er færdig trykker du \"Fortsæt\".",
+                "itemsLeft": {
+                    "one": "{{count}} post venstre",
+                    "other": "{{count}} items venstre"
+                },
+                "location": "Sted:",
+                "othersPresent": "Andre til stede:"
+            },
+            "2": {
+                "categories": {
+                    "extremelyChar": "Ekstremt karakteristisk",
+                    "extremelyUnchar": "Ekstremt ukarakteristisk",
+                    "fairlyChar": "Rimelig karakteristisk",
+                    "fairlyUnchar": "Rimelig ukarakteristisk",
+                    "neutral": "Hverken karakteristisk eller ukarakteristisk",
+                    "quiteChar": "Temmelig karakteristisk",
+                    "quiteUnchar": "Temmelig ukarakteristisk",
+                    "somewhatChar": "Noget karakteristisk",
+                    "somewhatUnchar": "Noget ukarakteristisk"
+                },
+                "instructions": "Beskriv nu situationen endnu mere præcist. Fra de tre boxe bedes du placere de forskellige items i ni boxe. Du kan trække items over fra en box til en anden, men hvis du putter for mange items i en og samme box vil overskriften vise rød. Overskriften bliver grøn, når der er det rette antal items i boxen."
+            }
+        }
+    },
+    "survey": {
+        "sections": {
+            "1": {
+                "instructions": "Velkommen! Vi er interesserede i situationer, som personer oplever, og i hvad personer gør i situationer. Du vil blive bedt om at beskrive en situation, som du for nyligt har oplevet samt hvad du gjorde i situationen. Du vil også blive stillet nogle spørgsmål vedrørende dine holdninger og værdier. Baseret på dine svar vil du, hvis du vælger det, blive givet muligheden for at modtage information om din personlighed, som vi håber du vil finde interessant. Det som følger vil tage under 1 time at gennemføre.                                                                                                            Start med at svare på et par spørgsmål omkring dig selv.",
+                "questions": {
+                    "1": {
+                        "label": "Alder"
+                    },
+                    "10": {
+                        "label": "Hvis, ja: Hvilken religion bekender du dig til?"
+                    },
+                    "11": {
+                        "label": "Hvilket land er du født i?"
+                    },
+                    "2": {
+                        "label": "Køn",
+                        "options": {
+                            "female": "Kvinde",
+                            "male": "Mand",
+                            "na": "Jeg ønsker ikke at svare",
+                            "other": "Andet"
+                        }
+                    },
+                    "3": {
+                        "label": "Hvad er din etnicitet?"
+                    },
+                    "4": {
+                        "label": "Hvad er dit modersmål (primære sprog)?"
+                    },
+                    "5": {
+                        "label": "På en skala fra 1 til 10, hvordan vil du beskrive din families økonomiske position?",
+                        "options": {
+                            "average": "Gennemsnitlig",
+                            "least": "Mindst velstillet",
+                            "most": "Mest velstillet"
+                        }
+                    },
+                    "6": {
+                        "label": "Fødeby"
+                    },
+                    "7": {
+                        "label": "Hjemby",
+                        "options": {
+                            "remoteRural": "Fjernere liggende yderområde",
+                            "rural": "Landområde",
+                            "suburban": "Provinsområde",
+                            "urban": "Byområde"
+                        }
+                    },
+                    "8": {
+                        "label": "På en skala fra 1 til 10, hvor religiøs er du?",
+                        "options": {
+                            "highlyReligious": "Meget religiøs",
+                            "notReligious": "Slet ikke religiøs",
+                            "preferNoAnswer": "Jeg ønsker ikke at svare"
+                        }
+                    },
+                    "9": {
+                        "label": "Bekender du dig til en religion?",
+                        "options": {
+                            "noLabel": "Nej",
+                            "preferNoAnswer": "Jeg ønsker ikke at svare",
+                            "yesLabel": "Ja"
+                        }
+                    }
+                }
+            },
+            "2": {
+                "instructions": {
+                    "firstSection": "Beskriv en oplevelse, som du havde i går, og som du husker godt",
+                    "secondSection": "En hvilken som helst oplevelse, som du havde i går, kan bruges; det er kun vigtigt, at det er en oplevelse, som du husker godt. Beskriv særligt hvad du foretog dig, hvor du var og hvem, der var til stede?",
+                    "thirdSection": "Skriv dine svar i boxene nedenfor"
+                },
+                "questions": {
+                    "11": {
+                        "characterCount": "0 ud af i alt 75 tegn brugt",
+                        "label": "Hvad foretog du dig på dette tidspunkt?"
+                    },
+                    "12": {
+                        "characterCount": "0 ud af i alt 75 tegn brugt",
+                        "label": "Hvor var du?"
+                    },
+                    "13": {
+                        "characterCount": "0 ud af i alt 75 tegn brugt",
+                        "label": "Hvem andre var til stede? (Hvis du var alene, skriv \"alene\")"
+                    },
+                    "14": {
+                        "label": "På hvilket cirka tidspunkt af døgnet begyndte din oplevelse?"
+                    }
+                }
+            }
+        }
+    },
+    "thankyou": {
+        "exitButton": "Exit for at afslutte studie",
+        "instructions": "Du kan nu vælge at afslutte eller at fortsætte for at modtage information omkring din personlighed baseret på dit udfyldte spørgeskema.",
+        "personalityFeedbackButton": "Modtag feedback på personlighed",
+        "title": "Tak!"
+    }
+};

--- a/app/locales/hr/config.js
+++ b/app/locales/hr/config.js
@@ -1,0 +1,16 @@
+// Ember-I18n includes configuration for common locales. Most users
+// can safely delete this file. Use it if you need to override behavior
+// for a locale or define behavior for a locale that Ember-I18n
+// doesn't know about.
+export default {
+  rtl: false,
+
+  pluralForm: function(count) {
+    if (count === 0) { return 'zero'; }
+    if (count === 1) { return 'one'; }
+    if (count === 2) { return 'two'; }
+    if (count < 5) { return 'few'; }
+    if (count >= 5) { return 'many'; }
+    return 'other';
+  }
+};

--- a/app/locales/hr/translations.js
+++ b/app/locales/hr/translations.js
@@ -1,0 +1,1103 @@
+export default {
+    "0": "0",
+    "1": "1",
+    "10": "10",
+    "100": "100",
+    "11": "11",
+    "12": "12",
+    "13": "13",
+    "14": "14",
+    "15": "15",
+    "16": "16",
+    "17": "17",
+    "18": "18",
+    "19": "19",
+    "2": "2",
+    "20": "20",
+    "21": "21",
+    "22": "22",
+    "23": "23",
+    "24": "24",
+    "25": "25",
+    "26": "26",
+    "27": "27",
+    "28": "28",
+    "29": "29",
+    "3": "3",
+    "30": "30",
+    "31": "31",
+    "32": "32",
+    "33": "33",
+    "34": "34",
+    "35": "35",
+    "36": "36",
+    "37": "37",
+    "38": "38",
+    "39": "39",
+    "4": "4",
+    "40": "40",
+    "41": "41",
+    "42": "42",
+    "43": "43",
+    "44": "44",
+    "45": "45",
+    "46": "46",
+    "47": "47",
+    "48": "48",
+    "49": "49",
+    "5": "5",
+    "50": "50",
+    "51": "51",
+    "52": "52",
+    "53": "53",
+    "54": "54",
+    "55": "55",
+    "56": "56",
+    "57": "57",
+    "58": "58",
+    "59": "59",
+    "6": "6",
+    "60": "60",
+    "61": "61",
+    "62": "62",
+    "63": "63",
+    "64": "64",
+    "65": "65",
+    "66": "66",
+    "67": "67",
+    "68": "68",
+    "69": "69",
+    "7": "7",
+    "70": "70",
+    "71": "71",
+    "72": "72",
+    "73": "73",
+    "74": "74",
+    "75": "75",
+    "76": "76",
+    "77": "77",
+    "78": "78",
+    "79": "79",
+    "8": "8",
+    "80": "80",
+    "81": "81",
+    "82": "82",
+    "83": "83",
+    "84": "84",
+    "85": "85",
+    "86": "86",
+    "87": "87",
+    "88": "88",
+    "89": "89",
+    "9": "9",
+    "90": "90",
+    "91": "91",
+    "92": "92",
+    "93": "93",
+    "94": "94",
+    "95": "95",
+    "96": "96",
+    "97": "97",
+    "98": "98",
+    "99": "99",
+    "Key": "Croatian Translation",
+    "consent": {
+        "button": {
+            "labelUnaccepted": "Molimo, prihvatite uvjete kako biste mogli nastaviti."
+        },
+        "checkboxLabel": "Pročitao sam i razumijem prethodne izjave i pristajem sudjelovati.",
+        "firstSection": "Dobro došli u naše istraživanje. Vaše će sudjelovanje biti jednokratno i trajat će manje od jednog sata. Od Vas se očekuje da opišete  situaciju u kojoj ste se nedavno našli i svoja ponašanja u toj situaciji. Bit će Vam postavljena i neka pitanja o Vašim vrijednostima i stavovima. Ako želite, po završetku istraživanja možete dobiti povratnu informaciju o svojim osobinama ličnosti.",
+        "secondSection": "Svi vaši odgovori bit će povjerljivi i označeni samo brojem (a ne Vašim imenom i prezimenom). Za istraživačke svrhe ti anonimni podaci mogu biti arhivirani u online bazu podataka koju vodi američki Centar za otvorene znanosti (www.cos.io). Da biste završili upitnik morate odgovoriti na svako pitanje, ali sudjelovanje  možete prekinuti u svakom trenutku bez ikakvih posljedica. Ono što želimo dobiti ovim istraživanjem uključuje bolje poznavanje osoba i njihova života u različitim kulturalnim kontekstima. Sudjelovanje u ovom istraživanju Vam neće naštetiti.",
+        "thirdSection": "Imate li bilo kakva pitanja o ovom istraživanju ili svojim pravima kao sudionik istraživanja, možete se obratiti prof. dr. Željku Jerneiću (zjerneic@ffzg.hr, Odsjek za psihologiju Filozofskog fakulteta Sveučilišta u Zagrebu, koji je odgovoran za prikupljanje podataka u Republici Hrvatskoj ili  na adresu e-pošte IRB@ucr.edu (University of California, Riverside, Office of Research Integrity) . Zahvaljujemo Vam na suradnji.",
+        "title": "Pristanak na sudjelovanje u istraživanju",
+        "versionHistory": "(Pristanak oblik verzija: 14. listopada 2016)"
+    },
+    "exitpage": {
+        "line1": "Zahvaljujemo na sudjelovanju!",
+        "line2": "Vaši odgovori su pohranjeni."
+    },
+    "feedback": {
+        "agree": "Ugodnost",
+        "consc": "Savjesnost",
+        "exitButton": "Izlaz",
+        "extra": "Ekstraverzija",
+        "firstSection": "Na temelju nekoliko desetljeća istraživanja, znanstvenici koji proučavaju ličnost slažu se da su najvažnije individualne razlike u osobinama ličnosti opisane pomoću pet osnovnih osobina poznatih kao 'Velikih pet': Ekstraverzija, Ugodnost, Savjesnost, Emocionalna stabilnost i Otvorenost prema iskustvu. Upitnikom koji ste upravo završili ostvarili ste bodove za svaku od tih osobina, a Vaši rezultati nalaze se u nastavku.",
+        "fourthSection": "Zahvaljujemo na sudjelovanju!",
+        "hiAgree": "Osobe s visokim rezultatom obično su pažljive i pristojne u socijalnim interakcijama i vole surađivati s drugima. Lako vjeruju ljudima i suosjećaju s onima u nevolji. Njihovi kolege ih obično vole, a uspostavljaju dobre i stabilne bliske odnose. Veća je vjerojatnost da su religiozni, da  rade na vodećim mjestima u zajednici  i bave se dobrovoljnim radom. Starije osobe obično postižu viši rezultat od mlađih.",
+        "hiConsc": "Oni koji ostvare visoki rezultat obično su organizirani i odgovorni. Trude se ostvariti svoje ciljeve i završe započete zadatke. U školovanju obično postižu više ocjene i uspješniji su u mnogim zanimanjima.Veća je vjerojatnost da su religiozni i imaju konzervativne političke stavove. Obično više vježbaju, boljeg su fizičkog zdravlja i žive dulje. Starije osobe obično postižu viši rezultat od mlađih.",
+        "hiExtra": "Osobe s visokim rezultatom pričljive su i energične. Vole biti okruženi ljudima i ne ustručavaju se nametnuti drugima u grupi. Obično imaju više prijatelja i partnera s kojima su u vezi te su popularniji od većine drugih. Za njih je veća vjerojatnost da  rade na vodećim mjestima u zajednici i da se bave dobrovoljnim radom. Draža im je energična glazba, više vježbaju i vjerojatnije je da se bave sportom. Češće doživljavaju pozitivne emocije, a na pozitivne događaju reagiraju snažnije.",
+        "hiNeurot": "Oni koji ostvare visoki rezultat većinom su emocionalno stabilne i čvrste osobe. Obično ostaju mirni i u stresnim situacijama, a nakon negativnih događaja brzo se mogu oporaviti. Osobe s visokim rezultatom na emocionalnoj stabilnosti obično su zadovoljnije životom.",
+        "hiOpen": "Oni koji ostvare visoki rezultat uglavnom su otvoreni prema novim aktivnostima i novim idejama. Obično su kreativni, intelektualno radoznali i s osjećajem za ljepotu i umjetnost. Više vole i uspješniji su u znanstvenim i umjetničkim zanimanjima. Vole klasičnu glazbu, džez, blues i rock glazbu.",
+        "labels": {
+            "high": "Visoko",
+            "low": "Nisko",
+            "medium": "Prosječno"
+        },
+        "loAgree": "Oni koji ostvari nizak rezultat izražavaju se izravno i bez okolišanja, čak i kad postoji opasnost da će započeti prepirku. Uživaju u nadmetanju, a obično su skeptični prema namjerama drugih. Obično imaju više plaće i vjerojatnije je da će se upuštati u neka rizična ponašanja, kao što su pušenje i agresivna vožnja.",
+        "loConsc": "Oni koji ostvare nizak rezultat skloni su djelovati spontano, a ne planirati, i lakše im je sagledati širu sliku nego obraćati pozornost na detalje. Vole 'skakati' s jednog zadatka na drugi, umjesto da ih pojedinačno završavaju. Skloni su se upuštati u rizičnija ponašanja, kao što su pušenje, konzumacija alkohola i zlouporaba droga.",
+        "loExtra": "Osobe s niskim rezultatom obično su socijalno i emocionalno suzdržane. U pravilu više vole samoću ili društvo malog broja bliskih prijatelja, a svoje mišljenje i osjećaje zadržavaju za sebe. Manje je vjerojatno da će se upuštati u uzbudljive aktivnosti ili rizična ponašanja kao što su pušenje i konzumacija alkohola.",
+        "loNeurot": "Oni koji ostvare nizak rezultat obično su emocionalno osjetljivi i promjenjivog su raspoloženja. Češće doživljavaju negativne emocije i snažnije reagiraju na negativne događaje. Mlađe osobe obično postižu niži rezultat od starijih.",
+        "loOpen": "Oni koji ostvare nizak rezultat obično su tradicionalni, praktični i vole se držati tradicionalnih načina u onome što rade. Više vole ono što im je poznato od nečeg novog te konkretno umjesto apstraktnog. Draža su im konvencionalna i praktična zanimanja kao što su zanati i trgovina, i u njima su uspješniji.",
+        "neurot": "Emocionalna stabilnost",
+        "open": "Otvorenost prema iskustvu",
+        "score": "Od mogućih 100 bodova, Vaš rezultat je:",
+        "secondSection": "Za svaku od pet osobina, rezultat iznad 60 može se smatrati visokim, a rezultat ispod 40 niskim. Opisi osoba s visokim i niskim rezultatom nalaze se u nastavku. Ako je Vaš rezultat između 40 i 60, Vaša će ličnost vjerojatno biti opisana kao prosječna s obzirom na navedene osobine.",
+        "thirdSection": "Nadamo se da Vam je drago što ste sudjelovali u ovom istraživanju.",
+        "title": "Vaša ličnost"
+    },
+    "flag": {
+        "chooseLanguage": "Odaberite jezik"
+    },
+    "global": {
+        "agreement": {
+            "agree": "Slažem se",
+            "agreeStrongly": "Potpuno se slažem",
+            "disagree": "Ne slažem se",
+            "disagreeStrongly": "Nimalo se ne slažem",
+            "neutral": "Neutralno; nemam mišljenje"
+        },
+        "char": {
+            "extremelyChar": "Izuzetno karakteristično",
+            "extremelyUnchar": "Izuzetno nekarakteristično",
+            "fairlyChar": "Prilično karakteristično",
+            "fairlyUnchar": "Prilično nekarakteristično",
+            "neutral": "Ni karakteristično ni nekarakteristično",
+            "quiteChar": "Vrlo karakteristično",
+            "quiteUnchar": "Vrlo nekarakteristično",
+            "somewhatChar": "Donekle karakteristično",
+            "somewhatUnchar": "Donekle nekarakteristično"
+        },
+        "continueLabel": "Nastavite",
+        "describe": {
+            "aGreatDeal": "U velikoj mjeri",
+            "aLittle": "Malo",
+            "notAtAll": "Uopće ne"
+        },
+        "noLabel": "Ne",
+        "previousLabel": "Prethodna stranica",
+        "progress": "Napredak",
+        "selectUnselected": "Izaberite",
+        "yesLabel": "Da"
+    },
+    "login": {
+        "changeButton": "Promjena jezika",
+        "defaultError": "Molimo, pokušajte ponovno kasnije",
+        "errorHeading": "Dogodila se greška za vrijeme prijave",
+        "invalidAuthError": "Nevažeća identifikacijska oznaka istraživanja ili ispitanika",
+        "participantID": "Oznaka ispitanika",
+        "studyID": "Oznaka istraživanja",
+        "youChose": "Izaberite:"
+    },
+    "measures": {
+        "questions": {
+            "1": {
+                "label": "Sveukupno gledano, je li situacija koju ste opisali bila pozitivno ili negativno iskustvo?",
+                "options": {
+                    "extremelyNeg": "Izuzetno negativno",
+                    "extremelyPos": "Izuzetno pozitivno",
+                    "fairlyNeg": "Prilično negativno",
+                    "fairlyPos": "Prilično pozitivno",
+                    "neither": "Ni negativno ni pozitivno",
+                    "quiteNeg": "Jako negativno",
+                    "quitePos": "Jako pozitivno",
+                    "somewhatNeg": "Donekle negativno",
+                    "somewhatPos": "Donekle pozitivno"
+                }
+            },
+            "10": {
+                "items": {
+                    "1": {
+                        "label": "U ovoj zemlji ima mnogo društvenih normi kojih bi se ljudi trebali pridržavati."
+                    },
+                    "2": {
+                        "label": "U ovoj su zemlji vrlo jasna očekivanja kako bi se ljudi trebali ponašati u većini situacija."
+                    },
+                    "3": {
+                        "label": "U ovoj se zemlji ljudi slažu u tome koja su ponašanja primjerena, a koja nisu primjerena u većini situacija."
+                    },
+                    "4": {
+                        "label": "Ljudi u ovoj zemlji imaju znatnu slobodu u odlučivanju kako se žele ponašati u većini situacija."
+                    },
+                    "5": {
+                        "label": "U ovoj zemlji, ako se netko ponaša na neodgovarajući način, izaziva snažno negodovanje drugih."
+                    },
+                    "6": {
+                        "label": "U ovoj se zemlji ljudi gotovo uvijek pridržavaju društvenih normi."
+                    }
+                },
+                "label": "Molimo, procijenite u kojoj se mjeri slažete ili ne slažete sa sljedećim izjavama:",
+                "options": {
+                    "agree": "Slažem se",
+                    "agreeStrongly": "Potpuno se slažem",
+                    "disagree": "Ne slažem se",
+                    "disagreeStrongly": "Nimalo se ne slažem",
+                    "neutral": "Neutralno; nemam mišljenje"
+                }
+            },
+            "11": {
+                "label": "Postoji li neka karakteristika Vaše ličnosti koju trenutačno pokušavate promijeniti?",
+                "options": {
+                    "no": "Ne",
+                    "yes": "Da"
+                }
+            },
+            "12": {
+                "label": "Koju karakteristiku pokušavate promijeniti?"
+            },
+            "13": {
+                "items": {
+                    "1": {
+                        "label": "Većina ljudi u osnovi je poštena."
+                    },
+                    "2": {
+                        "label": "Većina ljudi u osnovi je dobrodušna i ljubazna."
+                    },
+                    "3": {
+                        "label": "Većina ljudi vjeruje drugima."
+                    },
+                    "4": {
+                        "label": "Općenito, ja vjerujem drugima."
+                    },
+                    "5": {
+                        "label": "Većina ljudi je pouzdana."
+                    }
+                },
+                "label": "Molimo, procijenite u kojoj se mjeri slažete ili ne slažete sa sljedećim tvrdnjama:",
+                "options": {
+                    "agree": "Slažem se",
+                    "agreeStrongly": "Potpuno se slažem",
+                    "disagree": "Ne slažem se",
+                    "disagreeStrongly": "Nimalo se ne slažem",
+                    "neutral": "Neutralno; nemam mišljenje"
+                }
+            },
+            "14": {
+                "items": {
+                    "1": {
+                        "label": "U nesigurnim vremenima obično očekujem najbolje."
+                    },
+                    "2": {
+                        "label": "Ako nešto u vezi sa mnom može poći krivo, poći će krivo."
+                    },
+                    "3": {
+                        "label": "Uvijek sam optimističan u pogledu svoje budućnosti."
+                    },
+                    "4": {
+                        "label": "Rijetko očekujem da će se stvari razvijati kako je za mene povoljno."
+                    },
+                    "5": {
+                        "label": "Rijetko računam da će mi se dogoditi dobre stvari."
+                    },
+                    "6": {
+                        "label": "Sveukupno gledano, očekujem da će mi se dogoditi više dobrih nego loših stvari."
+                    }
+                },
+                "label": "Molimo, procijenite u kojoj se mjeri slažete ili ne slažete sa sljedećim tvrdnjama:",
+                "options": {
+                    "agree": "Slažem se",
+                    "agreeStrongly": "Potpuno se slažem",
+                    "disagree": "Ne slažem se",
+                    "disagreeStrongly": "Nimalo se ne slažem",
+                    "neutral": "Neutralno; nemam mišljenje"
+                }
+            },
+            "15": {
+                "items": {
+                    "1": {
+                        "label": "Ne bih se služio laskanjem da dobijem povišicu ili napredujem u poslu čak i kad bih vjerovao da će mi to uspjeti."
+                    },
+                    "10": {
+                        "label": "Želim da me ljudi vide kao važnu osobu visokog statusa."
+                    },
+                    "2": {
+                        "label": "Ako od nekoga nešto želim, smijat ću se i najgorim šalama te osobe."
+                    },
+                    "3": {
+                        "label": "Ne bih se pretvarao da mi se netko sviđa samo kako bih pridobio tu osobu da mi učini uslugu."
+                    },
+                    "4": {
+                        "label": "Kad bih znao da me nikada neće uhvatiti, bio bih spreman ukrasti velike novčane iznose."
+                    },
+                    "5": {
+                        "label": "Nikada ne bih prihvatio mito, čak i da je vrlo velike vrijednosti."
+                    },
+                    "6": {
+                        "label": "Bio bih u iskušenju koristiti krivotvoren novac, kada bih bio siguran da ću proći nekažnjeno."
+                    },
+                    "7": {
+                        "label": "Nije mi posebno važno imati puno novaca."
+                    },
+                    "8": {
+                        "label": "Predstavljalo bi mi veliko zadovoljstvo imati skupe i luksuzne stvari."
+                    },
+                    "9": {
+                        "label": "Mislim da imam pravo na više poštovanja od prosječne osobe."
+                    }
+                },
+                "label": "Molimo, procijenite u kojoj se mjeri slažete ili ne slažete sa sljedećim tvrdnjama:",
+                "options": {
+                    "agree": "Slažem se",
+                    "agreeStrongly": "Potpuno se slažem",
+                    "disagree": "Ne slažem se",
+                    "disagreeStrongly": "Nimalo se ne slažem",
+                    "neutral": "Neutralno; nemam mišljenje"
+                }
+            },
+            "16": {
+                "items": {
+                    "1": {
+                        "label": "U obitelji"
+                    },
+                    "2": {
+                        "label": "Među prijateljima"
+                    },
+                    "3": {
+                        "label": "U gradu u kojem živim"
+                    },
+                    "4": {
+                        "label": "U društvu"
+                    },
+                    "5": {
+                        "label": "U svijetu"
+                    }
+                },
+                "label": "Što mislite, u kojoj se mjeri Vaš život odvija u ovim okruženjima?",
+                "options": {
+                    "aLittle": "Malo",
+                    "completely": "Potpuno",
+                    "notAtAll": "Uopće ne",
+                    "quiteaBit": "Znatno"
+                }
+            },
+            "17": {
+                "items": {
+                    "1": {
+                        "label": "Zaslužujem da me smatraju značajnom osobom."
+                    },
+                    "2": {
+                        "label": "To što sam vrlo posebna osoba daje mi puno snage."
+                    },
+                    "3": {
+                        "label": "Svojim izvanrednim postignućima uspijevam biti središte pozornosti."
+                    },
+                    "4": {
+                        "label": "Većina ljudi na neki su način gubitnici."
+                    },
+                    "5": {
+                        "label": "Želim da moji suparnici ne uspiju."
+                    },
+                    "6": {
+                        "label": "Reagiram uzrujano ako umjesto mene netko drugi plijeni pažnju."
+                    }
+                },
+                "label": "Molimo, procijenite u kojoj se mjeri slažete ili ne slažete sa sljedećim tvrdnjama:",
+                "options": {
+                    "agree": "Slažem se",
+                    "agreeStrongly": "Potpuno se slažem",
+                    "disagree": "Ne slažem se",
+                    "disagreeStrongly": "Nimalo se ne slažem",
+                    "neutral": "Neutralno; nemam mišljenje"
+                }
+            },
+            "18": {
+                "label": "Koliko ste dosad bili uspješni u mijenjanju te karakteristike svoje ličnosti?",
+                "options": {
+                    "alittleSuccessful": "Malo",
+                    "completelySuccessful": "U potpunosti",
+                    "moderatelySuccessful": "Umjereno",
+                    "notatallSuccessful": "Uopće nisam",
+                    "verySuccessful": "Jako"
+                }
+            },
+            "2": {
+                "label": "Kako često doživljavate situacije slične ovoj koju ste upravo opisali?",
+                "options": {
+                    "hardlyEver": "Rijetko",
+                    "never": "Nikada",
+                    "occasionally": "Povremeno",
+                    "quiteOften": "Prilično često"
+                }
+            },
+            "3": {
+                "items": {
+                    "1": {
+                        "label": "Pokušao sam kontrolirati situaciju."
+                    },
+                    "10": {
+                        "label": "Bio sam živahan,  vrzmao se uokolo."
+                    },
+                    "11": {
+                        "label": "Zanimalo me što je netko imao reći."
+                    },
+                    "12": {
+                        "label": "Tražio sam savjet."
+                    },
+                    "13": {
+                        "label": "Ponašao sam se raspoloženo."
+                    },
+                    "14": {
+                        "label": "Izražavao sam samosažaljenje ili osjećaje da sam nečija žrtva."
+                    },
+                    "15": {
+                        "label": "Govorio sam glasno."
+                    },
+                    "16": {
+                        "label": "Pokazao sam visoki stupanj inteligencije."
+                    },
+                    "2": {
+                        "label": "Rekao sam o sebi negativne stvari."
+                    },
+                    "3": {
+                        "label": "Ponašao sam se natjecateljski."
+                    },
+                    "4": {
+                        "label": "Pokazao sam ambiciju."
+                    },
+                    "5": {
+                        "label": "Dominirao sam situacijom."
+                    },
+                    "6": {
+                        "label": "Pokazao sam veliki entuzijazam i visoku razinu energije."
+                    },
+                    "7": {
+                        "label": "Bio sam fizički aktivan."
+                    },
+                    "8": {
+                        "label": "Usredotočio sam se na zadatak ili ga naporno obavljao."
+                    },
+                    "9": {
+                        "label": "Bio sam suzdržan i bezizražajan."
+                    }
+                },
+                "label": "Molimo, ocijenite svoje ponašanje u situaciji koju ste opisali:",
+                "options": {
+                    "extremelyChar": "Izuzetno karakteristično",
+                    "extremelyUnchar": "Izuzetno nekarakteristično",
+                    "fairlyChar": "Prilično karakteristično",
+                    "fairlyUnchar": "Prilično nekarakteristično",
+                    "neutral": "Ni karakteristično ni nekarakteristično",
+                    "quiteChar": "Vrlo karakteristično",
+                    "quiteUnchar": "Vrlo nekarakteristično",
+                    "somewhatChar": "Donekle karakteristično",
+                    "somewhatUnchar": "Donekle nekarakteristično"
+                }
+            },
+            "4": {
+                "label": "Kako vidite sebe: jeste li pretežno osoba koja je potpuno spremna preuzeti rizike ili nastojite izbjeći preuzimanje rizika?",
+                "options": {
+                    "fullyPrepared": "Potpuno spreman preuzeti rizike",
+                    "unwilling": "Nerado preuzimam rizike"
+                }
+            },
+            "5": {
+                "items": {
+                    "1": {
+                        "label": "otvoren, društven"
+                    },
+                    "10": {
+                        "label": "netko tko se zanima za mnogo različitih stvari"
+                    },
+                    "11": {
+                        "label": "netko tko se rijetko kad osjeća uzbuđeno ili poletno"
+                    },
+                    "12": {
+                        "label": "sklon prigovarati drugima"
+                    },
+                    "13": {
+                        "label": "pouzdan, postojan"
+                    },
+                    "14": {
+                        "label": "promjenjivog raspoloženja, imam navale dobrog i lošeg raspoloženja"
+                    },
+                    "15": {
+                        "label": "domišljat, na dovitljive načine obavljam stvari"
+                    },
+                    "16": {
+                        "label": "obično sam mirna, šutljiva osoba"
+                    },
+                    "17": {
+                        "label": "netko tko malo suosjeća s drugima"
+                    },
+                    "18": {
+                        "label": "sistematičan, volim da je sve uredno"
+                    },
+                    "19": {
+                        "label": "katkad nervozan"
+                    },
+                    "2": {
+                        "label": "suosjećajan, mekog srca"
+                    },
+                    "20": {
+                        "label": "netko koga oduševljava umjetnost, glazba ili književnost"
+                    },
+                    "21": {
+                        "label": "dominantan, ponašam se kao vođa"
+                    },
+                    "22": {
+                        "label": "netko tko započinje prepirke s drugima"
+                    },
+                    "23": {
+                        "label": "netko tko se teško prihvaća posla"
+                    },
+                    "24": {
+                        "label": "netko tko se osjeća sigurno, zadovoljno samim sobom"
+                    },
+                    "25": {
+                        "label": "netko tko izbjegava intelektualne, filozofske rasprave"
+                    },
+                    "26": {
+                        "label": "manje aktivan nego drugi"
+                    },
+                    "27": {
+                        "label": "pomirljive naravi"
+                    },
+                    "28": {
+                        "label": "pomalo nemaran"
+                    },
+                    "29": {
+                        "label": "emotivno stabilan, nije me lako uzrujati"
+                    },
+                    "3": {
+                        "label": "sklon neorganiziranosti"
+                    },
+                    "30": {
+                        "label": "slabo kreativan"
+                    },
+                    "31": {
+                        "label": "katkad sramežljiv, povučen u sebe"
+                    },
+                    "32": {
+                        "label": "spreman pomoći i nesebičan prema drugima"
+                    },
+                    "33": {
+                        "label": "netko tko stvari drži čistima i urednima"
+                    },
+                    "34": {
+                        "label": "obuzet brigama"
+                    },
+                    "35": {
+                        "label": "netko tko cijeni umjetnost i ljepotu"
+                    },
+                    "36": {
+                        "label": "netko tko teško utječe na ljude"
+                    },
+                    "37": {
+                        "label": "katkad grub prema drugima"
+                    },
+                    "38": {
+                        "label": "efikasan, provodim stvari u djelo"
+                    },
+                    "39": {
+                        "label": "često tužan"
+                    },
+                    "4": {
+                        "label": "opušten, dobro se nosim sa stresom"
+                    },
+                    "40": {
+                        "label": "kompleksna, dubokoumna osoba"
+                    },
+                    "41": {
+                        "label": "pun energije"
+                    },
+                    "42": {
+                        "label": "sumnjičav prema namjerama drugih"
+                    },
+                    "43": {
+                        "label": "pouzdan, na mene se uvijek može računati"
+                    },
+                    "44": {
+                        "label": "netko tko kontrolira svoje emocije"
+                    },
+                    "45": {
+                        "label": "netko tko teško zamišlja stvari"
+                    },
+                    "46": {
+                        "label": "pričljiv"
+                    },
+                    "47": {
+                        "label": "katkad hladan i ravnodušan prema drugima"
+                    },
+                    "48": {
+                        "label": "netko tko ostavlja nered, ne posprema stvari"
+                    },
+                    "49": {
+                        "label": "netko tko se rijetko kad osjeća tjeskobno ili se boji"
+                    },
+                    "5": {
+                        "label": "netko tko ima malo umjetničkih interesa"
+                    },
+                    "50": {
+                        "label": "netko tko misli da su poezija i kazališne predstave dosadne"
+                    },
+                    "51": {
+                        "label": "netko tko više voli da drugi preuzmu zaduženja i odgovornost"
+                    },
+                    "52": {
+                        "label": "pristojan, pažljiv prema drugima"
+                    },
+                    "53": {
+                        "label": "ustrajan, radim dok ne završim zadatak"
+                    },
+                    "54": {
+                        "label": "netko tko se obično osjeća potišteno"
+                    },
+                    "55": {
+                        "label": "slabo zainteresiran za apstraktne ideje"
+                    },
+                    "56": {
+                        "label": "netko tko pokazuje puno entuzijazma"
+                    },
+                    "57": {
+                        "label": "netko tko misli najbolje o ljudima"
+                    },
+                    "58": {
+                        "label": "netko tko se katkad ponaša neodgovorno"
+                    },
+                    "59": {
+                        "label": "temperamentan, lako se uzbudim"
+                    },
+                    "6": {
+                        "label": "samosvjesna osoba"
+                    },
+                    "60": {
+                        "label": "originalan, iznosim nove ideje"
+                    },
+                    "7": {
+                        "label": "pristojan, prema drugima se odnosim s poštovanjem"
+                    },
+                    "8": {
+                        "label": "sklon ljenčarenju"
+                    },
+                    "9": {
+                        "label": "netko tko ostaje optimist i kad doživi neuspjeh"
+                    }
+                },
+                "label": "Molimo, procijenite u kojoj mjeri se slažete ili ne slažete sa sljedećim izjavama:\n\nJa sam…",
+                "options": {
+                    "agree": "Slažem se",
+                    "agreeStrongly": "Potpuno se slažem",
+                    "disagree": "Ne slažem se",
+                    "disagreeStrongly": "Nimalo se ne slažem",
+                    "neutral": "Neutralno; nemam mišljenje"
+                }
+            },
+            "6": {
+                "items": {
+                    "1": {
+                        "label": "Općenito gledano sebe smatram",
+                        "options": {
+                            "notHappy": "Nisam vrlo sretna osoba",
+                            "veryHappy": "Ja sam vrlo sretna osoba"
+                        }
+                    },
+                    "2": {
+                        "label": "U usporedbi s većinom ljudi oko sebe,  smatram da sam",
+                        "options": {
+                            "lessHappy": "Manje sretna osoba",
+                            "moreHappy": "Sretnija osoba"
+                        }
+                    },
+                    "3": {
+                        "label": "Neki su ljudi uglavnom vrlo sretni. Uživaju u životu bez obzira što se događa, uzimajući najviše od svega.\nU kojoj se mjeri ovaj opis odnosi na Vas?",
+                        "options": {
+                            "aGreatDeal": "Znatno",
+                            "notAtAll": "Uopće ne"
+                        }
+                    },
+                    "4": {
+                        "label": "Neki ljudi uglavnom nisu vrlo sretni. Iako nisu potišteni, čini se da nikada nisu onoliko sretni koliko bi mogli biti.\nU kojoj se mjeri ovaj opis odnosi na Vas?",
+                        "options": {
+                            "aGreatDeal": "U velikoj mjeri",
+                            "notAtAll": "Uopće ne"
+                        }
+                    }
+                },
+                "label": "Za svako od sljedećih pitanja, na ljestvici od 7 točaka označite onu koja Vas najbolje opisuje:"
+            },
+            "7": {
+                "items": {
+                    "1": {
+                        "label": "Vjerujem da smo sretni i ja i drugi oko mene."
+                    },
+                    "2": {
+                        "label": "Mislim da ljudi iz moje okoline imaju dobro mišljenje o meni."
+                    },
+                    "3": {
+                        "label": "Usrećujem one do kojih mi je stalo."
+                    },
+                    "4": {
+                        "label": "Iako je posve prosječan, moj je život stabilan."
+                    },
+                    "5": {
+                        "label": "Nemam većih briga ili strahova."
+                    },
+                    "6": {
+                        "label": "Mogu činiti što želim bez da drugima stvaram probleme."
+                    },
+                    "7": {
+                        "label": "Vjerujem da je moj život jednako sretan kao i život drugih oko mene."
+                    },
+                    "8": {
+                        "label": "Vjerujem da sam dosegao standard života jednak onome ljudi oko mene."
+                    },
+                    "9": {
+                        "label": "Uglavnom vjerujem da se meni stvari razvijaju jednako dobro kao i drugima oko mene."
+                    }
+                },
+                "label": "Molimo, procijenite u kojoj se mjeri slažete ili ne slažete sa sljedećim tvrdnjama:",
+                "options": {
+                    "agree": "Slažem se",
+                    "agreeStrongly": "Potpuno se slažem",
+                    "disagree": "Ne slažem se",
+                    "disagreeStrongly": "Nimalo se ne slažem",
+                    "neutral": "Neutralno; nemam mišljenje"
+                }
+            },
+            "8": {
+                "items": {
+                    "1": {
+                        "label": "Vjerovanje u religiju pomaže nam shvatiti značenje života."
+                    },
+                    "10": {
+                        "label": "Samo slabe osobe trebaju religiju."
+                    },
+                    "11": {
+                        "label": "Religija omogućuje ljudima bijeg iz stvarnosti."
+                    },
+                    "12": {
+                        "label": "Prakticiranje vjere ujedinjava ljude."
+                    },
+                    "13": {
+                        "label": "Za vjernike je vjerojatnije da će se držati moralnih standarda."
+                    },
+                    "14": {
+                        "label": "Religijska uvjerenja vode u neznanstveno razmišljanje."
+                    },
+                    "15": {
+                        "label": "Neznanje dovodi do vjerovanja u postojanje vrhovnog bića."
+                    },
+                    "16": {
+                        "label": "Za one koji traže znakove njegova postojanja, dokaza o vrhovnom biću ima posvuda."
+                    },
+                    "17": {
+                        "label": "Religija je u proturječju sa znanošću."
+                    },
+                    "2": {
+                        "label": "Religija pomaže ljudima da u svojim životima naprave dobre izbore."
+                    },
+                    "3": {
+                        "label": "Vjera pridonosi dobrom psihičkom zdravlju."
+                    },
+                    "4": {
+                        "label": "Religija usporava napredak čovječanstva."
+                    },
+                    "5": {
+                        "label": "Postoji vrhovno biće koje upravlja svemirom."
+                    },
+                    "6": {
+                        "label": "Religija čini ljude zdravijima."
+                    },
+                    "7": {
+                        "label": "Religija čini ljude sretnijima."
+                    },
+                    "8": {
+                        "label": "Vjerovanje u religiju čini ljude dobrim građanima."
+                    },
+                    "9": {
+                        "label": "Prakticiranje vjere otežava ljudima da razmišljaju samostalno."
+                    }
+                },
+                "label": "Molimo, procijenite u kojoj se mjeri slažete ili ne slažete sa sljedećim tvrdnjama:",
+                "options": {
+                    "believeLittle": "Djelomično vjerujem",
+                    "believeStrong": "Čvrsto vjerujem",
+                    "disbelieveLittle": "Djelomično ne vjerujem",
+                    "disbelieveStrong": "Uopće ne vjerujem",
+                    "neutral": "Neutralno; nemam mišljenje",
+                    "preferNoAnswer": "Radije ne bih odgovorio"
+                }
+            },
+            "9": {
+                "items": {
+                    "1": {
+                        "label": "Volite otvoreno reći što mislite i pokazati svoje osjećaje, čak i kad to ponekad može izazvati sukob."
+                    },
+                    "10": {
+                        "label": "Različito se ponašate kada ste s različitim ljudima."
+                    },
+                    "11": {
+                        "label": "Sebe doživljavate drukčije kada ste s različitim ljudima."
+                    },
+                    "12": {
+                        "label": "Sebe doživljavate jednako čak i kad ste u različitim društvenim okruženjima."
+                    },
+                    "13": {
+                        "label": "Ponašate se jednako čak i kad ste s različitim ljudima."
+                    },
+                    "2": {
+                        "label": "Pokušavate se prilagoditi ljudima oko sebe čak i kad to znači da prikrivate svoje osjećaje."
+                    },
+                    "3": {
+                        "label": "Stalo Vam je da sačuvate sklad u svojim vezama, čak i kad to znači da ne pokazujete svoje prave osjećaje."
+                    },
+                    "4": {
+                        "label": "Kada se s drugima ne slažete, smatrate da je dobro to i otvoreno pokazati."
+                    },
+                    "5": {
+                        "label": "Štitite svoje osobne interese čak i kad bi Vam to ponekad moglo narušiti odnose u obitelji."
+                    },
+                    "6": {
+                        "label": "Obično su Vam drugi važniji od Vas samih."
+                    },
+                    "7": {
+                        "label": "Brinete se za one koji su Vam bliski, čak i kad to znači da svoje osobne potrebe ostavljate po strani."
+                    },
+                    "8": {
+                        "label": "Osobna postignuća cijenite više nego dobre odnose s bliskim osobama."
+                    },
+                    "9": {
+                        "label": "Za dobrobit obitelji žrtvovali biste svoje osobne interese."
+                    }
+                },
+                "label": "Koliko dobro Vas opisuje svaka od ovih tvrdnji?",
+                "options": {
+                    "aLittle": "Malo",
+                    "exactly": "U potpunosti me opisuje",
+                    "moderately": "Osrednje",
+                    "notAtAll": "Uopće me ne opisuje",
+                    "veryWell": "Vrlo dobro"
+                }
+            }
+        }
+    },
+    "previouslogin": {
+        "line1": "Naši podaci pokazuju da ste već završili ovo istraživanje.",
+        "line2": "Ako je to pogreška, obratite se koordinatoru istraživanja u Republici Hrvatskoj, prof. dr. Željku Jerneiću."
+    },
+    "qsort": {
+        "rsq": {
+            "item": {
+                "SomoneCountedon": "Na nekoga od prisutnih (niste Vi) računa se da će nešto učiniti.",
+                "abusedVictimized": "Zlostavljani ste ili ste nečija žrtva.",
+                "adviceYou": "Drugi od Vas žele savjet.",
+                "ambition": "Ambiciju se može izraziti ili pokazati.",
+                "anxietyInducing": "Situacija je potencijalno uznemirujuća.",
+                "art": "Umjetnost je važan dio situacije.",
+                "askingYou": "Netko od Vas nešto traži.",
+                "assertivenessGoal": "Potrebna je odlučnost/energičnost da bi se ostvario cilj.",
+                "athleticsSports": "Prisutni se bave atletikom ili sportom.",
+                "blaming": "Netko Vas okrivljuje za nešto.",
+                "breakingRules": "Netko krši pravila.",
+                "clearRules": "Jasna pravila određuju prikladno ponašanje (poštuju li se pravila ili ne).",
+                "closeRelationships": "Prisutni su u međusobno bliskim osobnim odnosima.",
+                "comparingThemselves": "Prisutni se međusobno uspoređuju.",
+                "competing": "Prisutni se međusobno takmiče.",
+                "complex": "Situacija je složena.",
+                "complimentingYou": "Netko Vam daje komplimente ili Vas hvali.",
+                "conformToOthers": "Na Vas se vrši pritisak da se prilagodite postupcima drugih.",
+                "convinceYou": "Netko Vas pokušava u nešto uvjeriti.",
+                "countingOnYou": "Netko računa na Vas da ćete nešto napraviti.",
+                "criticizing": "Netko Vas kritizira.",
+                "decision": "Treba donijeti odluku.",
+                "desiresGratified": "Želje bi se mogle ispuniti (primjerice hrana, kupovanje, seks).",
+                "differentRoles": "Prisutni imaju različite društvene uloge ili su različitog statusa.",
+                "disagreeing": "Prisutni se ne slažu oko nečega.",
+                "dominate": "Netko Vam pokušava nametnuti svoju volju ili Vam naređivati.",
+                "emotionalThreats": "Postoje emocionalne prijetnje.",
+                "emotionsExpressed": "Mogu se izražavati emocije.",
+                "entertainment": "Prisutna je zabava.",
+                "family": "U ovoj je situaciji važna obitelj.",
+                "feelInadequate": "Situacija bi Vam mogla stvoriti osjećaj da joj niste dorasli.",
+                "femininity": "Moguće je pokazati ženstvenost.",
+                "food": "U ovoj je situaciji važna hrana.",
+                "frustrating": "Situacija je frustrirajuća (primjerice: nije moguće postići cilj).",
+                "goodImpression": "Važno Vam je da ostavite dobar dojam.",
+                "happeningOnce": "Mnogo se stvari događa istodobno.",
+                "honor": "U pitanju je čast.",
+                "hostile": "Situacija bi u prisutnih mogla izazvati neprijateljstvo.",
+                "humorous": "Situacija je komična ili potencijalno komična.",
+                "intellectuallyStimulating": "Situacija bi mogla biti intelektualno poticajna.",
+                "intelligence": "Inteligencija je važna (primjerice: intelektualna diskusija, treba riješiti složeni problem).",
+                "jobDone": "Posao se mora obaviti.",
+                "masculinity": "Moguće je pokazati muževnost.",
+                "minorDetails": "Sitnice su važne.",
+                "money": "Važan je novac.",
+                "moralIssues": "Moralna ili etička pitanja su važna.",
+                "music": "Glazba je važan dio ove situacije.",
+                "needsHelp": "Nekome treba pomoć.",
+                "negativeEmotions": "Situacija bi mogla pobuditi negativne emocije.",
+                "newRelationships": "Mogli bi se razviti novi odnosi.",
+                "noisy": "Situacija je bučna (ako je opis smješten nisko, znači da je situacija vrlo tiha).",
+                "notClear": "Nije jasno što se događa; situacija je neodređena.",
+                "oppositeSex": "Prisutnost osoba suprotnoga spola važan je dio ove situacije.",
+                "peopleGetAlong": "Prisutnima je važno da se slažu.",
+                "physicalAttractiveness": "Vaša fizička privlačnost je važna.",
+                "physicalThreats": "Postoje fizičke prijetnje.",
+                "physicallyActive": "Prisutni su fizički aktivni.",
+                "physicallyUncomfortable": "Situacija je fizički neugodna (primjerice: prevruće je, previše je ljudi, prehladno je, itd.). (Ako je opis smješten nisko, to podrazumijeva da je situacija fizički vrlo ugodna.)",
+                "playful": "Situacija je zabavna.",
+                "politics": "Politika je važna (primjerice: politička diskusija).",
+                "positiveEmotions": "Situacija bi mogla pobuditi pozitivne emocije.",
+                "potentiallyEnjoy": "Situacija bi mogla biti zabavna.",
+                "power": "Moć je važna.",
+                "quickAction": "Potrebno je brzo djelovati.",
+                "rapidlyChanging": "Situacija se brzo mijenja.",
+                "reassurance": "Netko treba ili želi ohrabrenje.",
+                "reassuringPresent": "Prisutna je osoba koja pruža podršku.",
+                "relevantHealth": "Situacija je bitna za Vaše zdravlje (primjerice: mogućnost bolesti, dolazak liječnika).",
+                "religion": "U ovoj situaciji bitna je vjera (primjerice: događaj ili diskusija povezana s vjerom).",
+                "romanticPartners": "Prisutni su (Vaši) potencijalni ili stvarni ljubavni partneri.",
+                "ruminateDaydream": "Moguće je razmišljati, sanjariti ili zanositi se.",
+                "selfControl": "Potrebna je samokontrola (vlastita ili drugih).",
+                "sensations": "Osjetilni doživljaji su važni (primjerice: dodira, okusa, mirisa, fizičkog kontakta).",
+                "sexuality": "Seksualnost je bitna.",
+                "shame": "Netko se srami.",
+                "simpleClearcut": "Situacija je jednostavna i jasna.",
+                "smallAnnoyances": "Situacija pomalo ide na živce.",
+                "socialInteraction": "Moguća je socijalna interakcija.",
+                "successCooperation": "Uspjeh zahtijeva suradnju.",
+                "takenCareOf": "Za nekoga se treba pobrinuti.",
+                "talkingExpected": "Pričanje se očekuje ili zahtijeva.",
+                "talkingPermitted": "Pričanje je dopušteno.",
+                "tenseUpset": "Situacija bi prisutne mogla učiniti napetima i uzrujanima.",
+                "tryingImpress": "Netko Vas pokušava impresionirati.",
+                "underThreat": "Nekome nešto prijeti.",
+                "unhappySuffering": "Netko je nesretan ili pati.",
+                "unusualIdeas": "Otvoreno se raspravlja o neobičnim idejama ili stajalištima.",
+                "verbalFluency": "Ima prilika za pokazivanje rječitosti (primjerice: debata, monolog, aktivna konverzacija).",
+                "workingHard": "Prisutni naporno rade.",
+                "youFocus": "Vi ste središte pozornosti."
+            }
+        },
+        "sections": {
+            "1": {
+                "activity": "Aktivnost:",
+                "categories": {
+                    "characteristic": "Karakteristično",
+                    "neutral": "Neutralno",
+                    "uncharacteristic": "Nije karakteristično"
+                },
+                "instructions": "A sada detaljnije opišite situaciju koju ste doživjeli. U slijedu će vam se prikazati 90 mogućih opisa. Svaki od njih premjestite u jedan od tri okvira. Za one koji točno opisuju situaciju izaberite okvir s desne strane s oznakom \"Karakteristično\", za opise koji situaciju ne opisuju točno ili je opisuju loše, izaberite okvir \"Nije karakteristično\" s lijeve strane, a za opise koji su nevažni, nejasni ili za koje niste sigurni kamo spadaju izaberite \"Neutralno\". Kada završite pritisnite \"Nastavi\".",
+                "itemsLeft": {
+                    "one": "{{count}} roj preostalih opisa",
+                    "other": "{{count}} stavka ostavi"
+                },
+                "location": "Mjesto:",
+                "othersPresent": "Ostali prisutni:"
+            },
+            "2": {
+                "categories": {
+                    "extremelyChar": "Izuzetno karakteristično",
+                    "extremelyUnchar": "Izuzetno nekarakteristično",
+                    "fairlyChar": "Prilično karakteristično",
+                    "fairlyUnchar": "Prilično nekarakteristično",
+                    "neutral": "Ni karakteristično ni nekarakteristično",
+                    "quiteChar": "Vrlo karakteristično",
+                    "quiteUnchar": "Vrlo nekarakteristično",
+                    "somewhatChar": "Donekle karakteristično",
+                    "somewhatUnchar": "Donekle nekarakteristično"
+                },
+                "instructions": "A sada opišite situaciju još podrobnije. Opise iz triju okvira rasporedite u devet okvira. Možete ih povlačiti iz jednoga u drugi okvir, ali ako u jedan od njih stavite previše opisa, oznaka kategorije okvira postat će crvene boje. Oznaka će postati zelene boje kada je u okviru točan broj opisa."
+            }
+        }
+    },
+    "survey": {
+        "sections": {
+            "1": {
+                "instructions": "Dobro došli! Zanimaju nas situacije koje netko doživi i kako se u njima ponaša. Opisat ćete situaciju koju ste nedavno doživjeli i što ste u toj situaciji radili. Također ćete odgovoriti na neka pitanja o svojim stavovima i vrijednostima. Kada završite upitnik, na temelju tih odgovora imat ćete priliku dobiti informacije o sebi i nadamo se da će Vam one biti zanimljive. Za ispunjavanje upitnika treba manje od jednog sata.\n\nZa početak odgovorite na nekoliko pitanja o sebi.",
+                "questions": {
+                    "1": {
+                        "label": "Dob"
+                    },
+                    "10": {
+                        "label": "Ako je tako, koje ste vjere?"
+                    },
+                    "11": {
+                        "label": "Država rođenja"
+                    },
+                    "2": {
+                        "label": "Spol",
+                        "options": {
+                            "female": "Ženski",
+                            "male": "Muški",
+                            "na": "Radije ne bih odgovorio",
+                            "other": "Drugo"
+                        }
+                    },
+                    "3": {
+                        "label": "Koje ste nacionalnosti?"
+                    },
+                    "4": {
+                        "label": "Koji je Vaš materinski jezik?"
+                    },
+                    "5": {
+                        "label": "Kako biste na ljestvici od 1 do 10 ocijenili ekonomski status svoje obitelji?",
+                        "options": {
+                            "average": "Prosječan",
+                            "least": "Izrazito nizak",
+                            "most": "Izrazito visok"
+                        }
+                    },
+                    "6": {
+                        "label": "Mjesto rođenja"
+                    },
+                    "7": {
+                        "label": "Prebivalište",
+                        "options": {
+                            "remoteRural": "udaljeno seosko",
+                            "rural": "seosko",
+                            "suburban": "prigradsko",
+                            "urban": "gradsko"
+                        }
+                    },
+                    "8": {
+                        "label": "Na ljestvici od 1 do 10, koliko ste religiozni?",
+                        "options": {
+                            "highlyReligious": "Izrazito",
+                            "notReligious": "Uopće nisam",
+                            "preferNoAnswer": "Radije ne bih odgovorio"
+                        }
+                    },
+                    "9": {
+                        "label": "Jeste li vjernik?",
+                        "options": {
+                            "noLabel": "Ne",
+                            "preferNoAnswer": "Radije ne bih odgovorio",
+                            "yesLabel": "Da"
+                        }
+                    }
+                }
+            },
+            "2": {
+                "instructions": {
+                    "firstSection": "Opišite neki svoj jučerašnji doživljaj koji dobro pamtite.",
+                    "secondSection": "Svaka situacija koju ste jučer doživjeli dolazi u obzir; važno je samo da je se dobro sjećate. Opišite što ste radili, gdje ste bili i tko je bio prisutan.",
+                    "thirdSection": "Svoje odgovore upišite u okvire ispod."
+                },
+                "questions": {
+                    "11": {
+                        "characterCount": "Upotrijebljeno 0 od 75 slovnih mjesta",
+                        "label": "Što ste u to vrijeme radili?"
+                    },
+                    "12": {
+                        "characterCount": "Upotrijebljeno 0 od 75 slovnih mjesta",
+                        "label": "Gdje ste bili?"
+                    },
+                    "13": {
+                        "characterCount": "Upotrijebljeno 0 od 75 slovnih mjesta",
+                        "label": "Tko je još bio prisutan? (Ako ste bili sami, upišite \"sam /sama\")."
+                    },
+                    "14": {
+                        "label": "Kada je otprilike počela ta situacija?"
+                    }
+                }
+            }
+        }
+    },
+    "thankyou": {
+        "exitButton": "Završite istraživanje i izađite iz programa",
+        "instructions": "Sada možete završiti sudjelovanje u istraživanju ili nastaviti kako biste saznali neke informacije o svojoj ličnosti na temelju upitnika koji ste ispunili.",
+        "personalityFeedbackButton": "Primite povratne informacije o svojoj ličnosti",
+        "title": "Hvala!"
+    }
+};


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-353

## Purpose
Add consent forms for english, plus translations for denmark and croatia.

## Summary of changes

See above.

## Testing notes
Verify translations, + correct consent forms for the following site IDs:
- CROA1.HR
- DANI1.DK
- INDIA1.ENG
- PAKI1.ENG
- UAE1.ENG
- USA5.ENG

