### PR TITLE
Add TOS link to page footer

### DIFF
--- a/app/templates/manage/login.hbs
+++ b/app/templates/manage/login.hbs
@@ -30,3 +30,9 @@
         </div>
     </div>
 </div>
+
+<div class="row">
+    <div class="col-md-6 col-md-offset-3 text-center">
+        <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md" target="_blank" rel="nofollow noopener">Terms of Use</a>
+    </div>
+</div>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">=6"
   },
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
     "ember-ajax": "^2.0.1",


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-358

## Purpose
Add a link to the terms of service on the `manage/login` route, *only*. 

This link will not appear on internal pages, and is only shown to collaborators / study admins- not to general study participants.

## Summary of changes
![screen shot 2017-01-25 at 1 03 41 pm](https://cloud.githubusercontent.com/assets/2957073/22302964/2867de58-e2ff-11e6-969d-89763e517aa8.png)


## Testing notes
Go to `/manage/login`. Confirm there is a link to the terms of service.

Confirm that when clicked, the link opens in a new tab or window.

Go to `/login`. Confirm that there is **not** a link to the terms of service on this page.
