### PR TITLE
[WIP] Communicate save failures to user

### DIFF
--- a/app/components/exp-frame-base/component.js
+++ b/app/components/exp-frame-base/component.js
@@ -1,0 +1,53 @@
+import DS from 'ember-data';
+
+import ExpFrameBase from 'exp-player/components/exp-frame-base/component';
+
+/**
+ * Custom version of frame base that allows ISP (but no other platform app) to provide special handling of
+ *   400 errors on save
+ *
+ * This might be useful to the generic platform, but putting it in ISP for the moment lets us reduce QA burden for
+ *   turnaround on a critical bug
+ */
+export default ExpFrameBase.extend({
+    toast: Ember.inject.service(),
+    i18n: Ember.inject.service(),
+
+    _save() {
+        // TODO: Verify that this is never called directly apart from next: ISP will likely break this assumption
+        var frameId = `${this.get('frameIndex')}-${this.get('id')}`;
+        // When exiting frame, save the data to the base player using the provided saveHandler
+        const payload = this.serializeContent();
+        return this.attrs.saveHandler(frameId, payload);
+    },
+
+    displayError(error) {
+        if (error instanceof DS.InvalidError) {
+            // Respond to 400 errors by showing error text. Most common reason for a 400 error would be
+            const msg = this.get('i18n').t('previousLogin.line2').string;
+            this.toast.error(msg);
+        } else {
+            // If this is not an error we intend to handle, reraise it (we except that adapters will handle 401 and
+            //   403 internally by redirecting to the login page)
+            throw err;
+        }
+    },
+
+    actions: {
+        save() {
+            this._save().catch(err => this.send('displayError', err));
+        },
+
+        next() {
+            var frameId = `${this.get('frameIndex')}-${this.get('id')}`;
+            this.send('setTimeEvent', 'nextFrame');
+
+            // Only advance the form if save succeeded
+            this._save()
+                .then(() => this.sendAction('next'))
+                .catch(err => this.send('displayError', err));
+            window.scrollTo(0, 0);
+        }
+    }
+
+});

--- a/app/components/exp-player/component.js
+++ b/app/components/exp-player/component.js
@@ -24,6 +24,13 @@ export default ExpPlayer.extend({
     },
 
     actions: {
+        saveFrame(frameId, frameData) {
+            // TODO: Override default behavior to work as a closure action. Eventually we can move this into the
+            //   shared platform, but are putting it in ISP for now as a temporary fix to ease QA burden
+            this.get('session.sequence').push(frameId);
+            this.get('session.expData')[frameId] = frameData;
+            return this.get('session').save();
+        },
         sessionCompleted() {
             // Mark the current user account as having completed a session, then, also update the session model
             // If this fails to save the account due to normal network issues, it will still update the session but

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -146,7 +146,7 @@ const translations = {
         "title": "Your Personality"
     },
     "flag": {
-        "chooseLanguage": "Please choose a language"
+        "chooseLanguage": "Please select your country and language"
     },
     "global": {
         "agreement": {

--- a/app/routes/participate/survey/index.js
+++ b/app/routes/participate/survey/index.js
@@ -1,38 +1,38 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  setupController(controller, session) {
-    this._super(controller, session);
-    controller.set('experiment', this.controllerFor('participate.survey').get('experiment'));
-    controller.set('session', session);
-    controller.set('pastSessions', []);
-  },
-  actions: {
-    willTransition(transition) {
-      this._super(transition);
-      var oldURL = this.router.generate(this.routeName);
-      var newURL = this.router.location.getURL();
-      if (oldURL !== newURL) {
-        this.router.location.setURL(oldURL);
-      }
+    setupController(controller, session) {
+        this._super(controller, session);
+        controller.set('experiment', this.controllerFor('participate.survey').get('experiment'));
+        controller.set('session', session);
+        controller.set('pastSessions', []);
+    },
+    actions: {
+        willTransition(transition) {
+            this._super(transition);
+            var oldURL = this.router.generate(this.routeName);
+            var newURL = this.router.location.getURL();
+            if (oldURL !== newURL) {
+                this.router.location.setURL(oldURL);
+            }
 
-      if (transition.targetName === 'participate.survey.results' || transition.targetName === 'exit') {
-        return true;
-      }
+            if (transition.targetName === 'participate.survey.results' || transition.targetName === 'exit') {
+                return true;
+            }
 
-      var frameIndex = this.controllerFor('participate.survey.index').get('frameIndex');
-      var framePage = this.controllerFor('participate.survey.index').get('framePage');
-      if (frameIndex !== 0) {
-        // Disable back button in qsort page 2, rating-form page 1, and thank-you page
-        if (!(frameIndex === 2 && framePage === 1) && frameIndex !== 3 && frameIndex !== 4) {
-          this.controllerFor('participate.survey.index').set('frameIndex', frameIndex - 1);
+            var frameIndex = this.controllerFor('participate.survey.index').get('frameIndex');
+            var framePage = this.controllerFor('participate.survey.index').get('framePage');
+            if (frameIndex !== 0) {
+                // Disable back button in qsort page 2, rating-form page 1, and thank-you page
+                if (!(frameIndex === 2 && framePage === 1) && frameIndex !== 3 && frameIndex !== 4) {
+                    this.controllerFor('participate.survey.index').set('frameIndex', frameIndex - 1);
+                }
+                // Update pages within the rating-form
+                if (frameIndex === 3 && framePage !== 0) {
+                    this.controllerFor('participate.survey.index').set('framePage', framePage - 1);
+                }
+            }
+            transition.abort();
         }
-        // Update pages within the rating-form
-        if (frameIndex === 3 && framePage !== 0) {
-          this.controllerFor('participate.survey.index').set('framePage', framePage - 1);
-        }
-      }
-      transition.abort();
     }
-  }
 });

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -42,7 +42,7 @@
 
 {{#bs-modal header=false body=false footer=false open=showLanguageSelector keyboard=false backdropClose=false backdrop=true}}
   {{#bs-modal-header closeButton=false}}
-    <h4>{{t 'flag.chooseLanguage'}}</h4>
+    <h4>Please select your country and language</h4>
   {{/bs-modal-header}}
   {{#bs-modal-body}}
     {{language-picker onPick=(action 'selectLanguage')}}

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "flag-icon-css": "^2.3.1",
     "bcryptjs": "^2.3.0",
     "swfobject": "*",
-    "file-saver": "^1.3.3"
+    "file-saver": "^1.3.3",
+    "toastr": "^2.1.3"
   },
   "devDependencies": {
     "font-awesome": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "ember-power-select": "1.0.0-beta.25",
     "ember-resolver": "^2.0.3",
     "ember-simple-auth": "1.1.0",
+    "ember-toastr": "1.5.0",
     "ember-truth-helpers": "1.2.0",
     "ember-welcome-page": "^1.0.1",
     "loader.js": "^4.0.1",


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-367

## Purpose
A rare edge case on production demonstrated that in the event of a 400 error, the user would be allowed to progress through the study- even though no data was being saved.

This fixes that by adding toast messaging

## Summary of changes
If survey can't be saved on the server, show an error message in the top right corner of the screen, and prevent the user from continuing.

- [ ] TODO: May require a change to translations

## Testing notes

1. Generate a fake product on staging with a bad schema, such that the ISP experiment is *designed* to fail every time. (TODO: Provide a guaranteed failure condition for QA)

2. On the first page of the study, enter responses as normal, then click next. Under the old system, JS console errors would appear, but the changed code should instead show an error message, and hold the user on that page until data is successfully submitted.

3. (important!) Verify that the adapter is allowed to deal with 401 or 403 errors as normal (by yanking user to login page), but that any other remaining class of error message must be dispatched by this custom UI. (eg 400, 500)
  - To force "invalid auth" errors without waiting several hours, see [LEI-345 steps to reproduce](https://openscience.atlassian.net/browse/LEI-345)