### PR TITLE
Add warning text for IE users

### DIFF
--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -35,6 +35,9 @@
       <div class="col-md-12">
         <h1>International Situations Project</h1>
         {{isp-jam-auth invalidAuth=invalidAuth authenticating=authenticating login=(action 'authenticate')}}
+          <p>
+              The International Situations Project does not support Internet Explorer. If you are using Internet Explorer, please switch to another browser.
+          </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/LEI-384

## Purpose
Login is broken on IE <= 11. Warn users not to try.

## Summary of changes
English-only warning due to time constraints.

## Testing notes
Go to login page. See text at bottom.
