### PR TITLE
Flag picker icon improvements [#SVCS-302][#SVCS-303]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-Refs: https://openscience.atlassian.net/browse/LEI-
+Refs: https://openscience.atlassian.net/browse/SVCS-
 
 ## Purpose
 

--- a/app/components/language-picker/countries.js
+++ b/app/components/language-picker/countries.js
@@ -106,7 +106,7 @@ export default [
         "name": "China"
     },
     {
-        "code": "CR",
+        "code": "HR",
         "languages": [
             {
                 "code": "hr-CR",

--- a/app/components/language-picker/countries.js
+++ b/app/components/language-picker/countries.js
@@ -308,7 +308,7 @@ export default [
         "languages": [
             {
                 "code": "lt-LT",
-                "name": "Latviešu"
+                "name": "Lietuvių"
             }
         ],
         "name": "Lithuania"


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/SVCS-302
https://openscience.atlassian.net/browse/SVCS-303

## Purpose
Address two client requests for flag picker

## Summary of changes
- Fix name of Lithuanian language
- Use correct flag for croatia (croatia, not costa rica)

Before:
![screen shot 2017-04-20 at 9 43 57 am](https://cloud.githubusercontent.com/assets/2957073/25233826/1d674538-25ae-11e7-8f29-8ae360440490.png)

![screen shot 2017-04-20 at 9 43 38 am](https://cloud.githubusercontent.com/assets/2957073/25233834/239fee6e-25ae-11e7-81fd-54f033943aba.png)


## Testing notes
- Verify that flag buttons look as expected
