### PR TITLE
Add icon/logo warning about not using IE for ISP

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -74,3 +74,7 @@
 .results-container {
   padding: 30px;
 }
+
+.supported-browser {
+  width: 1.5em;
+}

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -35,9 +35,23 @@
       <div class="col-md-12">
         <h1>International Situations Project</h1>
         {{isp-jam-auth invalidAuth=invalidAuth authenticating=authenticating login=(action 'authenticate')}}
-          <p>
-              The International Situations Project does not support Internet Explorer. If you are using Internet Explorer, please switch to another browser.
-          </p>
+        <p>
+          The International Situations Project does not support Internet Explorer. If you are using Internet Explorer, please switch to another browser.
+        </p>
+        <p>
+          <i class="supported-browser fa fa-times" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-check-square-o" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-check-square-o" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-check-square-o" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-check-square-o" aria-hidden="true"></i>
+        </p>
+        <p>
+          <i class="supported-browser fa fa-internet-explorer" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-safari" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-firefox" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-chrome" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-edge" aria-hidden="true"></i>
+        </p>
       </div>
     </div>
   </div>

--- a/app/templates/participate/login.hbs
+++ b/app/templates/participate/login.hbs
@@ -46,11 +46,11 @@
           <i class="supported-browser fa fa-check-square-o" aria-hidden="true"></i>
         </p>
         <p>
-          <i class="supported-browser fa fa-internet-explorer" aria-hidden="true"></i>
-          <i class="supported-browser fa fa-safari" aria-hidden="true"></i>
-          <i class="supported-browser fa fa-firefox" aria-hidden="true"></i>
-          <i class="supported-browser fa fa-chrome" aria-hidden="true"></i>
-          <i class="supported-browser fa fa-edge" aria-hidden="true"></i>
+          <i class="supported-browser fa fa-internet-explorer" title="Internet explorer (not supported)" aria-label="Internet explorer (not supported)"></i>
+          <i class="supported-browser fa fa-safari" title="Safari (supported)" aria-label="Safari (supported)"></i>
+          <i class="supported-browser fa fa-firefox" title="Firefox (supported)" aria-label="Firefox (supported)"></i>
+          <i class="supported-browser fa fa-chrome" title="Chrome (supported)" aria-label="Chrome (supported)"></i>
+          <i class="supported-browser fa fa-edge" title="Edge (supported)" aria-label="Edge (supported)"></i>
         </p>
       </div>
     </div>


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/SVCS-300

## Purpose
Help users in other languages know what browsers are supported.

## Summary of changes
Add pictorial hints for supported browsers. Each icon has a tooltip if you mouse over- brand names may not be translated so this may actually be helpful.
https://zh.wikipedia.org/wiki/Internet_Explorer

![screen shot 2017-06-01 at 2 02 48 pm](https://cloud.githubusercontent.com/assets/2957073/26693716/2741295c-46d3-11e7-89d5-4c6048b61b8f.png)

## Testing notes
Adds icons and new style used only here. QA likely optional.
