### PR TITLE
Changed default 'who-completed' page to alleviate admin page slowdown.

### DIFF
--- a/app/controllers/manage/who-completed.js
+++ b/app/controllers/manage/who-completed.js
@@ -5,7 +5,7 @@ import {writeCSV} from 'exp-models/utils/csv-writer';
 
 export default Ember.Controller.extend({
     queryParams: ['siteId'],
-    siteId: '',
+    siteId: siteNames[0],
 
     siteNames: siteNames,
 


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/SVCS-381

## Purpose
Fix slow loading on admin page


## Summary of changes

Changed default query from 'all users' to the first in the list. This way when the page loads, it doesn't have to query the entire data set, but a small sub section of it.


## Testing notes

