### PR TITLE
Changed from default queryParamsDidChange to custom one, stopping cer…

### DIFF
--- a/app/routes/manage/who-completed.js
+++ b/app/routes/manage/who-completed.js
@@ -19,5 +19,25 @@ export default Ember.Route.extend(AuthenticatedRouteMixin, {
             query['filter[extra.studyId]'] = params.siteId;
         }
         return this.store.queryEverything('account', query);
+    },
+    
+    actions: {
+
+        // Override Embers queryParamsDidChange function, and make a few modifications.
+        // The initial function uses 'this.refresh' which will call multiple times, causing transition aborts
+        // Replacing with nesting the call in a Ember.run.once fixes this
+        queryParamsDidChange(changed, totalPresent, removed){
+            //queryParams map
+            var qpMap = this.get('_qp').map;
+            var totalChanged = Object.keys(changed).concat(Object.keys(removed));
+            for (var i = 0; i < totalChanged.length; ++i){
+                var qp = qpMap[totalChanged[i]];
+                // the this.router.currentState variable causes a page refresh to fail this check. Prevents a failed promise. 
+                if (qp && this._optionsForQueryParam(qp).refreshModel && this.router.currentState) {
+                    Ember.run.once(this, this.refresh);
+                }
+            }
+            return true;
+        },
     }
 });


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/SVCS-393

## Purpose
Fix TransactionAborted rejected promise error and Unhandled Promise error detected.

## Summary of changes
setting a queryParams refreshModel variable to true causes Ember's defualt queryParamsDidChange function to fire multiple times, causing these errors.

Added a custom queryParamsDidChange which will only fire the refresh command once.

See commit message for more info.

Links from commit message:
issue: https://github.com/emberjs/ember.js/issues/5566 (old version of ember)
file where queryParamsDidChange is defined: https://github.com/emberjs/ember.js/blob/lts-2-8/packages/ember-routing/lib/system/route.js



## Testing notes

