### PR TITLE
Adding Hindi-India back as a language for production.

### DIFF
--- a/app/components/language-picker/countries.js
+++ b/app/components/language-picker/countries.js
@@ -3,7 +3,7 @@
 // TODO: This will need to be updated every time a new language is "released" and marked final
 export const languagesForProduction =  [
     "ar", "bg", "cs", "da", "de", "en", "es", "fi", "fr",
-    "he", "hr", "hu", "id", "is", "it", "ja", "ka", "ko", "lt", "lv",
+    "he", "hi", "hr", "hu", "id", "is", "it", "ja", "ka", "ko", "lt", "lv",
     "mk", "mr", "ms", "no", "pl", "pt", "ro", "ru",
     "sk", "sl", "sr", "th", "tr", "uk", "zh", "zh-hk"
 ];


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/SVCS-420

## Purpose
Add Hindi-India back as a language for production.

## Summary of changes
Added Hindi-India back onto the languages used for production

## Testing notes
India should now have 3 languages to choose from, Hindi being one of them.
